### PR TITLE
fix wifi-direct management for transport

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientWifiDirectService.java
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientWifiDirectService.java
@@ -169,9 +169,9 @@ public class BundleClientWifiDirectService extends Service implements WifiDirect
                 if (periodicExecutor == null) processBackgroundExchangeSetting();
             }
             case WIFI_DIRECT_MANAGER_GROUP_INFO_CHANGED -> {
-                var groupInfo = wifiDirectManager.getGroupInfo();
-                if (groupInfo != null && groupInfo.getOwner() != null) {
-                    completeConnectionWaiter(groupInfo);
+                var ownerAddress = wifiDirectManager.getGroupOwnerAddress();
+                if (ownerAddress != null) {
+                    completeConnectionWaiter(wifiDirectManager.getGroupInfo());
                 }
             }
         }
@@ -212,6 +212,7 @@ public class BundleClientWifiDirectService extends Service implements WifiDirect
         } catch (Exception e) {
             logger.log(WARNING, "Failed to connect to " + device.deviceName, e);
         } finally {
+            wifiDirectManager.disconnect();
             broadcastBundleClientWifiEvent(BundleClientWifiDirectEventType.WIFI_DIRECT_CLIENT_EXCHANGE_FINISHED,
                                            device.deviceAddress);
         }

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/RpcServer.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/RpcServer.java
@@ -10,8 +10,6 @@ import net.discdd.bundlerouting.service.BundleExchangeServiceImpl;
 import net.discdd.grpc.BundleSender;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -27,7 +25,6 @@ public class RpcServer {
     private static final Logger logger = Logger.getLogger(RpcServer.class.getName());
 
     // private final String TAG = "dddTransport";
-    private static final String inetSocketAddressIP = "192.168.49.1";
     private static final int port = 7777;
     private ServerState state = ServerState.SHUTDOWN;
 
@@ -46,7 +43,6 @@ public class RpcServer {
             return;
         }
         state = ServerState.PENDING;
-        SocketAddress address = new InetSocketAddress(inetSocketAddressIP, port);
         var bundleReceivePath = context.getExternalFilesDir(null).toPath().resolve("BundleTransmission/server");
         var bundleExchangeService = new BundleExchangeServiceImpl() {
             @Override
@@ -63,7 +59,7 @@ public class RpcServer {
             protected void bundleCompletion(BundleExchangeName bundleExchangeName) {
             }
         };
-        server = NettyServerBuilder.forAddress(address).addService(bundleExchangeService).build();
+        server = NettyServerBuilder.forPort(7777).addService(bundleExchangeService).build();
 
         logger.log(INFO, "Starting rpc server at: " + server.toString());
 

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/TransportWifiDirectService.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/TransportWifiDirectService.java
@@ -27,6 +27,7 @@ import net.discdd.wifidirect.WifiDirectStateListener;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * This service handles the Wifi Direct group and the gRPC server.
@@ -105,6 +106,8 @@ public class TransportWifiDirectService extends Service
         switch (action.type()) {
             case WIFI_DIRECT_MANAGER_GROUP_INFO_CHANGED:
                 var groupInfo = wifiDirectManager.getGroupInfo();
+                appendToClientLog("Group info: " + (groupInfo == null ? "N/A" : groupInfo.getClientList().stream().map(
+                        d -> d.deviceName).collect(Collectors.joining(", "))));
                 if (groupInfo == null || groupInfo.getClientList().isEmpty()) {
                     appendToClientLog("No clients connected. Shutting down gRPC server");
                     stopRpcServer();


### PR DESCRIPTION
* added retries to get around the race between client connecting and transport's server starting
* bind transport grpc to port rather than address and port
* streamline owner address tracking in wifi direct manager