### PR TITLE
need to explicitly call wifidirect initialize/shutdown

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientWifiDirectService.java
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientWifiDirectService.java
@@ -100,7 +100,7 @@ public class BundleClientWifiDirectService extends Service implements WifiDirect
             logger.log(SEVERE, "Failed to start foreground service", e);
         }
 
-        wifiDirectManager = new WifiDirectManager(this, null, this, false);
+        wifiDirectManager = new WifiDirectManager(this, this, false);
         wifiDirectManager.initialize();
         try {
             bundleTransmission =
@@ -117,18 +117,19 @@ public class BundleClientWifiDirectService extends Service implements WifiDirect
         intent.setType("text/plain");
         try {
             logger.log(FINE,
-                       String.format("Sending ADU %s:%d from %s", adu.getAppId(), adu.getADUId(), adu.getSource()));
+                       String.format(getString(R.string.sending_adu_s_d_from_s), adu.getAppId(), adu.getADUId(), adu.getSource()));
             var data = Files.readAllBytes(adu.getSource().toPath());
             intent.putExtra(Intent.EXTRA_TEXT, data);
             getApplicationContext().startForegroundService(intent);
         } catch (IOException e) {
             logger.log(WARNING,
-                       String.format("Sending ADU %s:%d from %s", adu.getAppId(), adu.getADUId(), adu.getSource()), e);
+                       String.format(getString(R.string.sending_adu_s_d_from_s), adu.getAppId(), adu.getADUId(), adu.getSource()), e);
         }
     }
 
     @Override
     public void onDestroy() {
+        if (wifiDirectManager != null) wifiDirectManager.shutdown();
         super.onDestroy();
     }
 
@@ -189,7 +190,7 @@ public class BundleClientWifiDirectService extends Service implements WifiDirect
             wifiDirectManager.getPeerList().stream()
                     .filter(peer -> peer.deviceAddress.equals(transport.getDeviceAddress())).findFirst()
                     .map(this::exchangeWith).ifPresent(bc -> {
-                        logger.info(String.format("Exchanged %d bundles to and %d bundles from %s", bc.bundlesSent(),
+                        logger.info(String.format(getString(R.string.exchanged_d_bundles_to_and_d_bundles_from_s), bc.bundlesSent(),
                                                   bc.bundlesReceived(), transport.getDeviceName()));
                     });
         }
@@ -289,7 +290,7 @@ public class BundleClientWifiDirectService extends Service implements WifiDirect
                 var bundleExchangeCounts =
                         bundleTransmission.doExchangeWithTransport("XX:XX:XX:XX:XX:XX", "BundleServer", serverAddress,
                                                                    port);
-                logger.log(INFO, String.format("Exchanged %d bundles to and %d bundles from server",
+                logger.log(INFO, String.format(getString(R.string.exchanged_d_bundles_to_and_d_bundles_from_server),
                                                bundleExchangeCounts.bundlesSent(),
                                                bundleExchangeCounts.bundlesReceived()));
                 completableFuture.complete(bundleExchangeCounts);

--- a/BundleClient/app/src/main/res/values/strings.xml
+++ b/BundleClient/app/src/main/res/values/strings.xml
@@ -42,4 +42,7 @@
     <string name="transfers_in_the_background">Do transfers in the background</string>
     <string name="PeerDetailedDescription">Last seen: %s\nLast exchange: %s\nLast Server Contact: %s\n</string>
     <string name="never">Never</string>
+    <string name="sending_adu_s_d_from_s">Sending ADU %s:%d from %s</string>
+    <string name="exchanged_d_bundles_to_and_d_bundles_from_s">Exchanged %d bundles to and %d bundles from %s</string>
+    <string name="exchanged_d_bundles_to_and_d_bundles_from_server">Exchanged %d bundles to and %d bundles from server</string>
 </resources>

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/TransportWifiDirectService.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/TransportWifiDirectService.java
@@ -84,7 +84,7 @@ public class TransportWifiDirectService extends Service
             logger.log(SEVERE, "Failed to start foreground service", e);
         }
 
-        wifiDirectManager = new WifiDirectManager(this, null, this, true);
+        wifiDirectManager = new WifiDirectManager(this, this, true);
         wifiDirectManager.initialize();
     }
 

--- a/android-core/src/main/java/net/discdd/wifidirect/WifiDirectManager.java
+++ b/android-core/src/main/java/net/discdd/wifidirect/WifiDirectManager.java
@@ -25,11 +25,6 @@ import android.net.wifi.p2p.WifiP2pGroup;
 import android.net.wifi.p2p.WifiP2pInfo;
 import android.net.wifi.p2p.WifiP2pManager;
 
-import androidx.annotation.NonNull;
-import androidx.lifecycle.DefaultLifecycleObserver;
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleOwner;
-
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -47,7 +42,6 @@ public class WifiDirectManager {
 
     private final IntentFilter intentFilter = new IntentFilter();
     private final Context context;
-    private final Lifecycle lifeCycle;
     private final List<WifiDirectStateListener> listeners = new ArrayList<>();
     private final boolean isOwner;
     private String deviceName;
@@ -61,23 +55,18 @@ public class WifiDirectManager {
     private boolean wifiDirectEnabled;
     private boolean discoveryActive;
 
-    /**
-     * @param context   AppcompatActivity Context returned with a
-     *                  AppCompatActivity.getApplication() call in
-     *                  your main activity
-     * @param lifeCycle AppActivity Lifecycle returned with a
-     *                  AppCompatActivity.getLifeCycle() call in
-     *                  your main activity
-     */
-    public WifiDirectManager(Context context, Lifecycle lifeCycle, WifiDirectStateListener listener, boolean isOwner) {
+    public WifiDirectManager(Context context, WifiDirectStateListener listener, boolean isOwner) {
         this.context = context;
-        this.lifeCycle = lifeCycle;
         listeners.add(listener);
         this.isOwner = isOwner;
+        intentFilter.addAction(WIFI_P2P_STATE_CHANGED_ACTION);
+        intentFilter.addAction(WIFI_P2P_PEERS_CHANGED_ACTION);
+        intentFilter.addAction(WIFI_P2P_CONNECTION_CHANGED_ACTION);
+        intentFilter.addAction(WIFI_P2P_THIS_DEVICE_CHANGED_ACTION);
+        intentFilter.addAction(WIFI_P2P_DISCOVERY_CHANGED_ACTION);
     }
 
     public void initialize() {
-        this.registerIntents();
         this.manager = (WifiP2pManager) this.context.getSystemService(Context.WIFI_P2P_SERVICE);
         if (manager == null) {
             logger.log(INFO, "Cannot get Wi-Fi system service");
@@ -93,11 +82,6 @@ public class WifiDirectManager {
 
         this.receiver = new WifiDirectBroadcastReceiver();
         registerWifiIntentReceiver();
-        if (lifeCycle != null) {
-            WifiDirectLifeCycleObserver lifeCycleObserver = new WifiDirectLifeCycleObserver(this);
-            this.lifeCycle.addObserver(lifeCycleObserver);
-        }
-
         manager.requestDeviceInfo(channel, this::processDeviceInfo);
     }
 
@@ -131,18 +115,6 @@ public class WifiDirectManager {
                 notifyActionToListeners(WIFI_DIRECT_MANAGER_DEVICE_INFO_CHANGED);
             }
         }
-    }
-
-    /**
-     * Register Android Intents more commonly known as events we
-     * want to listen to for this device.
-     */
-    private void registerIntents() {
-        intentFilter.addAction(WIFI_P2P_STATE_CHANGED_ACTION);
-        intentFilter.addAction(WIFI_P2P_PEERS_CHANGED_ACTION);
-        intentFilter.addAction(WIFI_P2P_CONNECTION_CHANGED_ACTION);
-        intentFilter.addAction(WIFI_P2P_THIS_DEVICE_CHANGED_ACTION);
-        intentFilter.addAction(WIFI_P2P_DISCOVERY_CHANGED_ACTION);
     }
 
     public String getDeviceName() {
@@ -297,6 +269,7 @@ public class WifiDirectManager {
         manager.cancelConnect(channel, null);
         manager.stopPeerDiscovery(channel, null);
         manager.stopListening(channel, cal);
+        unregisterWifiIntentReceiver();
         return cal;
     }
 
@@ -336,30 +309,6 @@ public class WifiDirectManager {
     }
 
     public record WifiDirectEvent(WifiDirectEventType type, String message) {}
-
-    /**
-     * Inner Class to hook into activity Lifecycle functions
-     * and register/unregister BroadcastReceiver
-     * Note this may need to be modified when turning WifiDirectManager into
-     * a service
-     */
-    private class WifiDirectLifeCycleObserver implements DefaultLifecycleObserver {
-        public WifiDirectManager manager;
-
-        public WifiDirectLifeCycleObserver(WifiDirectManager manager) {
-            this.manager = manager;
-        }
-
-        @Override
-        public void onResume(@NonNull LifecycleOwner owner) {
-            registerWifiIntentReceiver();
-        }
-
-        @Override
-        public void onPause(@NonNull LifecycleOwner owner) {
-            unregisterWifiIntentReceiver();
-        }
-    }
 
     /**
      * A BroadcastReceiver that notifies of important wifi p2p events.


### PR DESCRIPTION
since we are using wifidirect from services, we don't have a lifecycle to hook into. so, we need to make sure to explicitly call initialize/shutdown in service onCreate/onDestroy