### PR TITLE
update transport wifi direct status when perms change

### DIFF
--- a/BundleTransport/app/src/main/res/layout/fragment_transport_wifi_direct.xml
+++ b/BundleTransport/app/src/main/res/layout/fragment_transport_wifi_direct.xml
@@ -45,6 +45,7 @@
             android:id="@+id/change_device_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:visibility="gone"
             android:orientation="vertical">
         <TextView
                 android:text="@string/phone_name_must_start_with_ddd"

--- a/BundleTransport/app/src/main/res/values/strings.xml
+++ b/BundleTransport/app/src/main/res/values/strings.xml
@@ -40,4 +40,5 @@
     <string name="local_wifi">Local Wifi</string>
     <string name="permissions">Permissions</string>
     <string name="logs">Logs</string>
+    <string name="check_permissions_and_that_wifi_is_enabled">Check Permissions and that Wifi is enabled</string>
 </resources>

--- a/android-core/src/main/java/net/discdd/android/fragments/PermissionsFragment.java
+++ b/android-core/src/main/java/net/discdd/android/fragments/PermissionsFragment.java
@@ -74,6 +74,9 @@ public class PermissionsFragment extends Fragment {
                                                   if (view != null) {
                                                       view.permissionCheckbox.setChecked(r);
                                                   }
+                                                  if (r) {
+                                                      trackGrantedPermission(p);
+                                                  }
                                               });
                                               if (neededPermissions.isEmpty()) {
                                                   promptPending = false;
@@ -89,31 +92,6 @@ public class PermissionsFragment extends Fragment {
 
     // TODO: in the future, we should enable removing from this set
     HashSet<String> grantedPermissions = new HashSet<>();
-
-    /*
-     * The Main activity uses this to call us back with the results of permission requests
-     */
-    public void processPermissionResults(String[] permissions, int[] grantResults) {
-        logger.log(Level.INFO, "Permission request results:");
-        for (var i = 0; i < permissions.length; i++) {
-            boolean permissionGranted = grantResults[i] == PackageManager.PERMISSION_GRANTED;
-            logger.log(Level.INFO, permissions[i] + " " + (permissionGranted ? "granted" : "denied"));
-            if (permissionGranted) {
-                trackGrantedPermission(permissions[i]);
-            }
-            var view = neededPermissions.remove(permissions[i]);
-            if (view != null) {
-                view.permissionCheckbox.setChecked(permissionGranted);
-            }
-        }
-        if (neededPermissions.isEmpty()) {
-            promptPending = false;
-        } else {
-            String[] permissionsToRequest = neededPermissions.keySet().toArray(new String[0]);
-            logger.info("Requesting " + Arrays.toString(permissionsToRequest));
-            activityResultLauncher.launch(permissionsToRequest);
-        }
-    }
 
     private void trackGrantedPermission(String permissions) {
         if (grantedPermissions.contains(permissions)) {

--- a/android-core/src/main/java/net/discdd/wifidirect/WifiDirectManager.java
+++ b/android-core/src/main/java/net/discdd/wifidirect/WifiDirectManager.java
@@ -175,11 +175,13 @@ public class WifiDirectManager {
         this.manager.createGroup(this.channel, new WifiP2pManager.ActionListener() {
             @Override
             public void onSuccess() {
+                logger.log(INFO, "Wifi direct group created");
                 requestGroupInfo().thenAccept(completableFuture::complete);
             }
 
             @Override
             public void onFailure(int reasonCode) {
+                logger.log(SEVERE, "Wifi direct group creation failed with reason code: " + reasonCode);
                 requestGroupInfo().thenAccept(completableFuture::complete);
             }
         });
@@ -390,13 +392,14 @@ public class WifiDirectManager {
                     if (state == WifiP2pManager.WIFI_P2P_STATE_ENABLED) {
                         logger.log(INFO, "WifiDirect enabled");
                         wifiDirectEnabled = true;
+                        manager.requestDeviceInfo(channel, WifiDirectManager.this::processDeviceInfo);
                         manager.requestDiscoveryState(channel, state1 -> discoveryActive =
                                 state1 == WifiP2pManager.WIFI_P2P_DISCOVERY_STARTED);
-                        manager.requestPeers(channel, peers -> discoveredPeers = new HashSet<>(peers.getDeviceList()));
                     } else {
                         logger.log(INFO, "WifiDirect not enabled");
                         wifiDirectEnabled = false;
                     }
+                    notifyActionToListeners(WifiDirectEventType.WIFI_DIRECT_MANAGER_INITIALIZED);
                 }
                 case WIFI_P2P_PEERS_CHANGED_ACTION -> {
                     // Broadcast intent action indicating that the available peer list has changed.


### PR DESCRIPTION
move the TransportWifiDirectService binding to the BundleTransportActivity so that we can refresh device info when the BundleTransportActivity sees the permissions change.