### PR TITLE
change the server port to 7778

### DIFF
--- a/bundleserver/src/main/resources/application.yml
+++ b/bundleserver/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
 
 grpc:
   server:
-    port: 8080
+    port: 7778
 server:
   port: 8081
 bundle-server:


### PR DESCRIPTION
8080 is often a proxy port and when exposed to the internet invites probes. 7778 is one different from the normal transport port.