### PR TITLE
issue #111 fix the dependabot problems for grpc

### DIFF
--- a/bundle-core/pom.xml
+++ b/bundle-core/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <protobuf.version>3.23.4</protobuf.version>
+        <protobuf.version>3.25.5</protobuf.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>
         <grpc.version>1.58.0</grpc.version>
     </properties>

--- a/bundleserver/pom.xml
+++ b/bundleserver/pom.xml
@@ -18,7 +18,7 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<protobuf.version>3.23.4</protobuf.version>
+		<protobuf.version>3.25.5</protobuf.version>
 		<grpc.version>1.58.0</grpc.version>
 	</properties>
 	<profiles>


### PR DESCRIPTION
Updated the version of protobuf used to  3.25.5, this is the next stable version that dependabot itself recommended.