### PR TITLE
Implemented notification on both client and transport

### DIFF
--- a/BundleClient/app/src/main/AndroidManifest.xml
+++ b/BundleClient/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <permission android:name="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_READ" android:protectionLevel="normal" />
     <uses-feature android:name="android.hardware.usb.host" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:name="net.discdd.crashreports.AcraApp"
         android:icon="@drawable/bundleclient_icon"

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientWifiDirectService.java
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientWifiDirectService.java
@@ -9,6 +9,7 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ServiceInfo;
@@ -302,6 +303,22 @@ public class BundleClientWifiDirectService extends Service implements WifiDirect
             completableFuture.complete(FAILED_EXCHANGE_COUNTS);
             return completableFuture;
         }
+
+        NotificationChannel channel =
+                new NotificationChannel("DDD-Exchange", "DDD Bundle Client", NotificationManager.IMPORTANCE_HIGH);
+        channel.setDescription("Initiating Bundle Exchange...");
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, "DDD-Client")
+                .setSmallIcon(R.drawable.bundleclient_icon)
+                .setContentTitle("Exchanging with Transport")
+                .setContentText("Initiating Bundle Exchange...")
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(false)
+                .setOngoing(true);
+
+        NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.notify(1002, builder.build());
+
         // we want to use the executor to make sure that only one exchange is going on at a time
         periodicExecutor.submit(() -> {
             try {
@@ -312,6 +329,12 @@ public class BundleClientWifiDirectService extends Service implements WifiDirect
                 completableFuture.complete(FAILED_EXCHANGE_COUNTS);
             }
         });
+
+        completableFuture.thenApply(ex -> {
+            notificationManager.cancel(1002);
+            return null;
+        });
+
         return completableFuture;
     }
 

--- a/BundleTransport/app/src/main/AndroidManifest.xml
+++ b/BundleTransport/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="Manifest.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/TransportWifiDirectService.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/TransportWifiDirectService.java
@@ -171,7 +171,6 @@ public class TransportWifiDirectService extends Service
     }
 
     private void appendToClientLog(String message) {
-
         var intent = new Intent(getApplicationContext(), TransportWifiDirectFragment.class);
         intent.setAction(NET_DISCDD_BUNDLETRANSPORT_CLIENT_LOG_ACTION);
         intent.putExtra("message", message);

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/TransportWifiDirectService.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/TransportWifiDirectService.java
@@ -23,6 +23,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import net.discdd.android.fragments.LogFragment;
 import net.discdd.bundlerouting.service.BundleExchangeServiceImpl;
+import net.discdd.client.bundletransmission.BundleTransmission;
 import net.discdd.pathutils.TransportPaths;
 import net.discdd.wifidirect.WifiDirectManager;
 import net.discdd.wifidirect.WifiDirectStateListener;
@@ -52,6 +53,7 @@ public class TransportWifiDirectService extends Service
     private WifiDirectManager wifiDirectManager;
     private SharedPreferences sharedPreferences;
     Context getApplicationContext;
+    private NotificationManager notificationManager;
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -77,7 +79,7 @@ public class TransportWifiDirectService extends Service
                                                                   NotificationManager.IMPORTANCE_HIGH);
             channel.setDescription("DDD Transport Service");
 
-            var notificationManager = getSystemService(NotificationManager.class);
+            notificationManager = getSystemService(NotificationManager.class);
             notificationManager.createNotificationChannel(channel);
 
             Notification notification =
@@ -114,12 +116,30 @@ public class TransportWifiDirectService extends Service
                 appendToClientLog("Group info: " + (groupInfo == null ? "N/A" :
                         groupInfo.getClientList().stream().map(d -> d.deviceName).collect(Collectors.joining(", "))));
                 if (groupInfo == null || groupInfo.getClientList().isEmpty()) {
+                    if (notificationManager != null) {
+                        notificationManager.cancel(1001);
+                    }
+
                     appendToClientLog("No clients connected. Shutting down gRPC server");
                     stopRpcServer();
                 } else {
                     appendToClientLog(String.format("%d clients connected. Starting gRPC server",
                                                     groupInfo.getClientList().size()));
                     startRpcServer();
+
+                    NotificationChannel channel =
+                            new NotificationChannel("DDD-Exchange", "DDD Bundle Transport", NotificationManager.IMPORTANCE_HIGH);
+                    channel.setDescription("Initiating Bundle Exchange...");
+
+                    NotificationCompat.Builder builder = new NotificationCompat.Builder(this, "DDD-Transport")
+                            .setSmallIcon(R.drawable.bundletransport_icon)
+                            .setContentTitle("Exchanging with Client")
+                            .setContentText("Initiating Bundle Exchange...")
+                            .setPriority(NotificationCompat.PRIORITY_HIGH)
+                            .setAutoCancel(false)
+                            .setOngoing(true);
+
+                    notificationManager.notify(1001, builder.build());
                 }
         }
         broadcastWifiEvent(action);
@@ -151,6 +171,7 @@ public class TransportWifiDirectService extends Service
     }
 
     private void appendToClientLog(String message) {
+
         var intent = new Intent(getApplicationContext(), TransportWifiDirectFragment.class);
         intent.setAction(NET_DISCDD_BUNDLETRANSPORT_CLIENT_LOG_ACTION);
         intent.putExtra("message", message);


### PR DESCRIPTION
A notification should pop up on both the client's and transport's phone after the client clicks on "exchanging data" if there is new data to be exchanged. It will disappear after the exchange is complete.

However, the user can manually dismiss the notification before the exchange is completed