### PR TITLE
fixed improper fragment instantiation

### DIFF
--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.java
@@ -142,7 +142,8 @@ public class BundleTransportActivity extends AppCompatActivity {
         logFragment = new TitledFragment(getString(R.string.logs), LogFragment.newInstance());
 
         permissionsViewModel = new ViewModelProvider(this).get(PermissionsViewModel.class);
-        titledPermissionsFragment = new TitledFragment("Permissions", PermissionsFragment.newInstance());
+        permissionsFragment = PermissionsFragment.newInstance();
+        titledPermissionsFragment = new TitledFragment("Permissions", permissionsFragment);
         fragments.add(titledPermissionsFragment);
 
         tabLayout = findViewById(R.id.tabs);


### PR DESCRIPTION
fixed a bug such that the permissions fragment is instantiated to it's proper field in BundleTransportActivity.
The app will not crash anymore when run. 