### PR TITLE
view model async coroutines

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientActivity.java
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientActivity.java
@@ -87,9 +87,11 @@ public class BundleClientActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        logger.log(INFO, "onCreate method invoked!");
 
-        sharedPreferences =
-                getSharedPreferences(BundleClientWifiDirectService.NET_DISCDD_BUNDLECLIENT_SETTINGS, MODE_PRIVATE);
+        sharedPreferences = getSharedPreferences(BundleClientWifiDirectService.NET_DISCDD_BUNDLECLIENT_SETTINGS, MODE_PRIVATE);
+        var appPreferences = getSharedPreferences("app_prefs", MODE_PRIVATE);
+        boolean isFirstLaunch = appPreferences.getBoolean("is_first_launch", true);
 
         ComponentName comp;
         try {
@@ -119,6 +121,7 @@ public class BundleClientActivity extends AppCompatActivity {
         }
 
         LogFragment.registerLoggerHandler();
+        logger.log(INFO, "This log runs right after log registration");
 
         permissionsViewModel = new ViewModelProvider(this).get(PermissionsViewModel.class);
         permissionsFragment = PermissionsFragment.newInstance();
@@ -153,6 +156,14 @@ public class BundleClientActivity extends AppCompatActivity {
         }
         else {
             logger.log(WARNING, "Usbmanager was null, failed to connect");
+        }
+
+        if (isFirstLaunch) {
+            logger.log(INFO, "this is the FIRST launch!");
+            appPreferences.edit().putBoolean("is_first_launch", false).apply();
+            logger.log(INFO, "value of is_first_launch: " + appPreferences.getBoolean("is_first_launch", true));
+        } else {
+            logger.log(INFO, "nope this NOT the FIRST launch!");
         }
     }
 

--- a/android-core/src/main/java/net/discdd/viewmodels/ConnectivityViewModel.kt
+++ b/android-core/src/main/java/net/discdd/viewmodels/ConnectivityViewModel.kt
@@ -7,9 +7,11 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import java.util.logging.Level
 import java.util.logging.Level.INFO
 import java.util.logging.Logger
@@ -35,34 +37,36 @@ class ConnectivityViewModel(
     }
 
     private fun createAndRegisterConnectivityManager() {
-        logger.log(INFO, "Registering connectivity manager")
-        val networkRequest: NetworkRequest = NetworkRequest.Builder()
-            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-            .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
-            .build()
+        viewModelScope.launch {
+            logger.log(INFO, "Registering connectivity manager")
+            val networkRequest: NetworkRequest = NetworkRequest.Builder()
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+                .build()
 
-        val serverConnectNetworkCallback = object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                logger.log(INFO, "Available network: $network")
-                _state.update { it.copy(networkConnected = true) }
+            val serverConnectNetworkCallback = object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    logger.log(INFO, "Available network: $network")
+                    _state.update { it.copy(networkConnected = true) }
+                }
+
+                override fun onLost(network: Network) {
+                    logger.log(Level.WARNING, "Lost network connectivity")
+                    _state.update { it.copy(networkConnected = false) }
+                }
+
+                override fun onUnavailable() {
+                    logger.log(Level.WARNING, "Unavailable network connectivity")
+                    _state.update { it.copy(networkConnected = false) }
+                }
+
+                override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
+                    logger.log(Level.WARNING, "Blocked network connectivity")
+                }
             }
 
-            override fun onLost(network: Network) {
-                logger.log(Level.WARNING, "Lost network connectivity")
-                _state.update { it.copy(networkConnected = false) }
-            }
-
-            override fun onUnavailable() {
-                logger.log(Level.WARNING, "Unavailable network connectivity")
-                _state.update { it.copy(networkConnected = false) }
-            }
-
-            override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
-                logger.log(Level.WARNING, "Blocked network connectivity")
-            }
+            connectivityManager.registerNetworkCallback(networkRequest, serverConnectNetworkCallback)
         }
-
-        connectivityManager.registerNetworkCallback(networkRequest, serverConnectNetworkCallback)
     }
 }


### PR DESCRIPTION
Building with Kotlin and ViewModels allow us to access the viewModelScope. We can leverage this by safe-launching computationally expensive methods or methods that require view-model dependency. 

In DDD's case, it's best to use viewModelScope for methods that interact with our defined services.

Notes: 
- viewModelScope might be overkill for methods that just update state.
- if a top level method is called with viewModelScope, the methods called within that are encapsulated in the same scope.