### PR TITLE
Add null check for senderId

### DIFF
--- a/bundle-core/src/main/java/net/discdd/client/bundlerouting/ClientRouting.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundlerouting/ClientRouting.java
@@ -73,6 +73,10 @@ public class ClientRouting {
      * None
      */
     public void updateMetaData(String senderId) throws ClientMetaDataFileException {
+        if (senderId == null) {
+            throw new IllegalArgumentException("senderId cannot be null");
+        }
+
         long count = 1;
 
         if (metadata.containsKey(senderId)) {


### PR DESCRIPTION
Don't allow the value of senderId to be null. The value is null whenever we can't  process the recency blob. 