### PR TITLE
Validate sender

### DIFF
--- a/bundle-core/src/main/java/net/discdd/client/bundlerouting/ClientRouting.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundlerouting/ClientRouting.java
@@ -76,8 +76,8 @@ public class ClientRouting {
     public void updateMetaData(String senderId) throws ClientMetaDataFileException {
         if (senderId == null) {
             logger.log(WARNING, ("senderId cannot be null"));
+            return;
         }
-
         long count = 1;
 
         if (metadata.containsKey(senderId)) {

--- a/bundle-core/src/main/java/net/discdd/client/bundlerouting/ClientRouting.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundlerouting/ClientRouting.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
 
 public class ClientRouting {
 
@@ -74,7 +75,7 @@ public class ClientRouting {
      */
     public void updateMetaData(String senderId) throws ClientMetaDataFileException {
         if (senderId == null) {
-            throw new IllegalArgumentException("senderId cannot be null");
+            logger.log(WARNING, ("senderId cannot be null"));
         }
 
         long count = 1;

--- a/bundle-core/src/main/java/net/discdd/client/bundlerouting/ClientRouting.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundlerouting/ClientRouting.java
@@ -73,6 +73,10 @@ public class ClientRouting {
      * None
      */
     public void updateMetaData(String senderId) throws ClientMetaDataFileException {
+        if (senderId == null) {
+            throw new IllegalArgumentException("senderId cannot be null");
+        }
+
         long count = 1;
 
         if (metadata.containsKey(senderId)) {


### PR DESCRIPTION
Don't allow the value of senderId to be null. The value is null whenever we can't process the recency blob.
