### PR TITLE
move modular components to android-core

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientActivity.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientActivity.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import net.discdd.UsbConnectionManager
 import net.discdd.bundleclient.screens.HomeScreen
 import net.discdd.screens.LogFragment
 import net.discdd.theme.ComposableTheme

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/ClientUsbScreen.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/ClientUsbScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat.startActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import net.discdd.bundleclient.R
-import net.discdd.bundleclient.UsbConnectionManager
+import net.discdd.UsbConnectionManager
 import net.discdd.bundleclient.viewmodels.UsbState
 import net.discdd.bundleclient.viewmodels.UsbViewModel
 

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/HomeScreen.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/HomeScreen.kt
@@ -26,16 +26,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberPermissionState
 import kotlinx.coroutines.launch
+import net.discdd.UsbConnectionManager
 import net.discdd.bundleclient.R
-import net.discdd.bundleclient.UsbConnectionManager
 import net.discdd.bundleclient.WifiServiceManager
-import net.discdd.bundleclient.viewmodels.HomeViewModel
 import net.discdd.screens.LogScreen
+import net.discdd.screens.NotificationBottomSheet
 import net.discdd.screens.PermissionScreen
-import androidx.lifecycle.viewmodel.compose.viewModel
+import net.discdd.viewmodels.SettingsViewModel
 
 data class TabItem(
     val title: String,
@@ -45,7 +46,7 @@ data class TabItem(
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun HomeScreen(
-    viewModel: HomeViewModel = viewModel()
+    viewModel: SettingsViewModel = viewModel()
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/WifiDirectScreen.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/WifiDirectScreen.kt
@@ -120,7 +120,7 @@ fun WifiDirectScreen(
             if (!nearbyWifiState.status.isGranted) {
                 WifiPermissionBanner(numDenied, nearbyWifiState) {
                     // if user denies access twice, manual access in settings is required
-                    if (numDenied > 2) {
+                    if (numDenied >= 2) {
                         val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
                             data = Uri.fromParts("package", context.packageName, null)
                         }

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/UsbViewModel.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/UsbViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import net.discdd.bundleclient.UsbConnectionManager
+import net.discdd.UsbConnectionManager
 import net.discdd.bundleclient.WifiServiceManager
 import java.io.File
 import java.nio.file.Files

--- a/BundleClient/app/src/main/res/values/strings.xml
+++ b/BundleClient/app/src/main/res/values/strings.xml
@@ -62,7 +62,4 @@
     <string name="reload">Reload</string>
     <string name="to_settings_text">To enable our app to manage app-related files on this device and your USB storage, please toggle \"Yes\" for BundleClient in your settings. We assure you that only files created by our app will be accessed. Protecting user privacy and maintaining ethical practices are our top priorities.</string>
     <string name="to_settings_button">To Settings</string>
-    <string name="ask_notification_permissions" translatable="false">Don\'t miss important messages like bundle upload progress and application activity</string>
-    <string name="turn_on_notifications" translatable="false">Turn on notifications</string>
-    <string name="close_bottom_sheet" translatable="false">Close bottom sheet</string>
 </resources>

--- a/android-core/src/main/java/net/discdd/UsbConnectionManager.kt
+++ b/android-core/src/main/java/net/discdd/UsbConnectionManager.kt
@@ -1,4 +1,4 @@
-package net.discdd.bundleclient
+package net.discdd
 
 import android.content.BroadcastReceiver
 import android.content.Context

--- a/android-core/src/main/java/net/discdd/screens/NotificationBottomSheet.kt
+++ b/android-core/src/main/java/net/discdd/screens/NotificationBottomSheet.kt
@@ -1,4 +1,4 @@
-package net.discdd.bundleclient.screens
+package net.discdd.screens
 
 import android.Manifest
 import android.app.Application
@@ -35,13 +35,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberPermissionState
-import net.discdd.bundleclient.R
-import net.discdd.bundleclient.viewmodels.HomeViewModel
+import net.discdd.android_core.R
+import net.discdd.viewmodels.SettingsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
 @Composable
 fun NotificationBottomSheet(
-    viewModel: HomeViewModel
+    viewModel: SettingsViewModel
 ) {
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var showBottomSheet by remember { mutableStateOf(true) }
@@ -87,7 +87,7 @@ fun NotificationBottomSheet(
                 )
 
                 Text(
-                    text = stringResource(R.string.ask_notification_permissions),
+                    text = stringResource(R.string.ask_notification_desc),
                     style = MaterialTheme.typography.bodyMedium,
                     color = Color.Gray,
                     modifier = Modifier.padding(bottom = 8.dp)
@@ -122,5 +122,5 @@ fun NotificationBottomSheet(
 @Preview(showBackground = true)
 @Composable
 fun NotificationBottomSheetPreview() {
-    NotificationBottomSheet(HomeViewModel(Application()))
+    NotificationBottomSheet(SettingsViewModel(Application()))
 }

--- a/android-core/src/main/java/net/discdd/screens/PermissionScreen.kt
+++ b/android-core/src/main/java/net/discdd/screens/PermissionScreen.kt
@@ -5,10 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContract
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -35,7 +31,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.viewmodel.compose.viewModel
 import net.discdd.theme.ComposableTheme
 import net.discdd.viewmodels.PermissionItemData

--- a/android-core/src/main/java/net/discdd/viewmodels/SettingsViewModel.kt
+++ b/android-core/src/main/java/net/discdd/viewmodels/SettingsViewModel.kt
@@ -1,4 +1,4 @@
-package net.discdd.bundleclient.viewmodels
+package net.discdd.viewmodels
 
 import android.app.Application
 import android.content.Context.MODE_PRIVATE
@@ -6,25 +6,25 @@ import androidx.lifecycle.AndroidViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class HomeViewModel(
+class SettingsViewModel(
     application: Application
 ): AndroidViewModel(application) {
     private val context get() = getApplication<Application>()
-    private val sharedPref = context.getSharedPreferences(NET_DISCDD_BUNDLECLIENT_FIRST_OPEN, MODE_PRIVATE)
+    private val sharedPref = context.getSharedPreferences(NET_DISCDD_VIEWMODELS_FIRST_OPEN, MODE_PRIVATE)
     private val _firstOpen = MutableStateFlow(true)
     val firstOpen = _firstOpen.asStateFlow()
 
     init {
-        val firstOpenCached = sharedPref.getBoolean(NET_DISCDD_BUNDLECLIENT_FIRST_OPEN, true)
+        val firstOpenCached = sharedPref.getBoolean(NET_DISCDD_VIEWMODELS_FIRST_OPEN, true)
         _firstOpen.value = firstOpenCached
     }
 
     fun onFirstOpen() {
         _firstOpen.value = false
-        sharedPref.edit().putBoolean(NET_DISCDD_BUNDLECLIENT_FIRST_OPEN, false).apply()
+        sharedPref.edit().putBoolean(NET_DISCDD_VIEWMODELS_FIRST_OPEN, false).apply()
     }
 
     companion object {
-        const val NET_DISCDD_BUNDLECLIENT_FIRST_OPEN: String = "net.discdd.bundleclient.FIRST_OPEN"
+        const val NET_DISCDD_VIEWMODELS_FIRST_OPEN: String = "net.discdd.viewmodels.FIRST_OPEN"
     }
 }

--- a/android-core/src/main/res/values/strings.xml
+++ b/android-core/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="manual_action_required" translatable="false"><![CDATA[Manual action is required to grant access to nearby devices. To proceed, click \'Enable\' -> \'Permissions\' -> \'Nearby devices\' -> \'Allow\']]></string>
     <string name="generic_ask_permission" translatable="false">This permission is needed to discover and connect to nearby devices for file transfers.</string>
     <string name="urgent_ask_permission" translatable="false">Getting access to nearby devices is important for transport functionality. Please grant us access to continue. Thank you :D</string>
-    <string name="close_bottom_sheet">Close bottom sheet</string>
-    <string name="turn_on_notifications">Turn on notifications</string>
-    <string name="ask_notification_desc">Don\'t miss important messages like bundle upload progress and application activity</string>
+    <string name="close_bottom_sheet" translatable="false">Close bottom sheet</string>
+    <string name="turn_on_notifications" translatable="false">Turn on notifications</string>
+    <string name="ask_notification_desc" translatable="false">Don\'t miss important messages like bundle upload progress and application activity</string>
 </resources>

--- a/android-core/src/main/res/values/strings.xml
+++ b/android-core/src/main/res/values/strings.xml
@@ -15,4 +15,7 @@
     <string name="manual_action_required" translatable="false"><![CDATA[Manual action is required to grant access to nearby devices. To proceed, click \'Enable\' -> \'Permissions\' -> \'Nearby devices\' -> \'Allow\']]></string>
     <string name="generic_ask_permission" translatable="false">This permission is needed to discover and connect to nearby devices for file transfers.</string>
     <string name="urgent_ask_permission" translatable="false">Getting access to nearby devices is important for transport functionality. Please grant us access to continue. Thank you :D</string>
+    <string name="close_bottom_sheet">Close bottom sheet</string>
+    <string name="turn_on_notifications">Turn on notifications</string>
+    <string name="ask_notification_desc">Don\'t miss important messages like bundle upload progress and application activity</string>
 </resources>


### PR DESCRIPTION
- In this pr, I move the `UsbConnectionManger` to `/android-core` so that I can use it for the Transport's version of the USB functionality. 
- I also create a central `SettingsViewModel` for the notifications bottom sheet because it needs to be used on both transport and client.
- I also fix a small error in counting how many times a user denies the permission before bringing them to settings. I also did some minor renaming.