### PR TITLE
easter egg mode for admin tabs

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/HomeScreen.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/HomeScreen.kt
@@ -52,53 +52,58 @@ fun HomeScreen(
     val scope = rememberCoroutineScope()
     val showUsbScreen by UsbConnectionManager.usbConnected.collectAsState()
     val firstOpen by viewModel.firstOpen.collectAsState()
+    val showEasterEgg by viewModel.showEasterEgg.collectAsState()
     val nearbyWifiState = rememberPermissionState(
             Manifest.permission.NEARBY_WIFI_DEVICES
     )
 
-    val standardTabs = remember {
-        listOf(
-            TabItem(
-                title = context.getString(R.string.home_tab),
-                screen = {
-                    WifiDirectScreen(
-                        serviceReadyFuture = WifiServiceManager.serviceReady,
-                        nearbyWifiState = nearbyWifiState
-                    )
-                }
-            ),
-            TabItem(
-                title = context.getString(R.string.server_tab),
-                screen = { ServerScreen() }
-            ),
-            TabItem(
-                title = context.getString(R.string.logs_tab),
-                screen = { LogScreen() }
-            ),
-            TabItem(
-                title = context.getString(R.string.bm_tab),
-                screen = { ManagerScreen() }
-            ),
-            TabItem(
-                title = context.getString(R.string.permissions_tab),
-                screen = { PermissionScreen() }
-            )
+    val standardTabs = listOf(
+        TabItem(
+            title = context.getString(R.string.home_tab),
+            screen = {
+                WifiDirectScreen(
+                    serviceReadyFuture = WifiServiceManager.serviceReady,
+                    nearbyWifiState = nearbyWifiState
+                ) { viewModel.onToggleEasterEgg() }
+            }
+        ),
+        TabItem(
+            title = context.getString(R.string.server_tab),
+            screen = { ServerScreen() }
+        ),
+        TabItem(
+            title = context.getString(R.string.bm_tab),
+            screen = { ManagerScreen() }
+        ),
+    )
+
+    val adminTabs = listOf(
+        TabItem(
+            title = context.getString(R.string.logs_tab),
+            screen = { LogScreen() }
+        ),
+        TabItem(
+            title = context.getString(R.string.permissions_tab),
+            screen = { PermissionScreen() }
+        ),
+    )
+
+    val usbTab = listOf(
+        TabItem(
+            title = context.getString(R.string.usb_tab),
+            screen = { UsbScreen() }
         )
-    }
-    val usbTab = listOf(TabItem(
-        title = context.getString(R.string.usb_tab),
-        screen = { UsbScreen() }
-    ))
+    )
 
     var tabItems by remember {
         mutableStateOf(standardTabs)
     }
-    LaunchedEffect(showUsbScreen) {
-        tabItems = if (showUsbScreen) {
-             usbTab + standardTabs
-        } else {
-            standardTabs
-        }
+
+    LaunchedEffect(showUsbScreen, showEasterEgg) {
+        var newTabs = standardTabs.toMutableList()
+        if (showUsbScreen) newTabs += usbTab
+        if (showEasterEgg) newTabs += adminTabs
+        tabItems = newTabs
     }
 
     Surface(

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/WifiDirectScreen.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/WifiDirectScreen.kt
@@ -52,6 +52,7 @@ import net.discdd.bundleclient.BundleClientWifiDirectService
 import net.discdd.bundleclient.R
 import net.discdd.bundleclient.viewmodels.PeerDevice
 import net.discdd.bundleclient.viewmodels.WifiDirectViewModel
+import net.discdd.screens.EasterEgg
 import net.discdd.screens.WifiPermissionBanner
 import java.util.concurrent.CompletableFuture
 
@@ -64,7 +65,8 @@ fun WifiDirectScreen(
     preferences: SharedPreferences = LocalContext.current.getSharedPreferences(
         BundleClientWifiDirectService.NET_DISCDD_BUNDLECLIENT_SETTINGS,
         Context.MODE_PRIVATE
-    )
+    ),
+    onToggle: () -> Unit,
 ) {
     val state by viewModel.state.collectAsState()
     val numDenied by viewModel.numDenied.collectAsState()
@@ -132,7 +134,10 @@ fun WifiDirectScreen(
                 }
             }
 
-            Text(text = "ClientId: ${state.clientId}")
+            EasterEgg(
+                content = { Text(text = "ClientId: ${state.clientId}") },
+                onToggle = onToggle,
+            )
             Text(text = "Connected Device Addresses: ${state.connectedDeviceText}")
             Text(text = "Discovery Status: ${state.deliveryStatus}")
             var checked by remember {
@@ -231,8 +236,6 @@ fun PeerItem(
 fun WifiDirectScreenPreview() {
     WifiDirectScreen(
         serviceReadyFuture = CompletableFuture(),
-        nearbyWifiState = rememberPermissionState(
-            Manifest.permission.NEARBY_WIFI_DEVICES
-        )
-    )
+        nearbyWifiState = rememberPermissionState(Manifest.permission.NEARBY_WIFI_DEVICES)
+    ) {}
 }

--- a/android-core/src/main/java/net/discdd/screens/EasterEgg.kt
+++ b/android-core/src/main/java/net/discdd/screens/EasterEgg.kt
@@ -1,0 +1,42 @@
+package net.discdd.screens
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+@Composable
+fun EasterEgg(
+    content: @Composable () -> Unit,
+    onToggle: () -> Unit
+) {
+    var clickTimes by remember { mutableStateOf<List<Long>>(emptyList()) }
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = Modifier
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null // conceals ripple effect
+            ) {
+                val now = System.currentTimeMillis()
+                clickTimes = (clickTimes + now)
+                    .filter { now - it <= 3000 }
+                    .takeLast(7)
+                if (clickTimes.size == 7) {
+                    val timeDiff = clickTimes.last() - clickTimes.first()
+                    if (timeDiff <= 3000) {
+                        onToggle()
+                        clickTimes = emptyList()
+                    }
+                }
+            }
+    ) {
+        content()
+    }
+}

--- a/android-core/src/main/java/net/discdd/viewmodels/SettingsViewModel.kt
+++ b/android-core/src/main/java/net/discdd/viewmodels/SettingsViewModel.kt
@@ -10,13 +10,17 @@ class SettingsViewModel(
     application: Application
 ): AndroidViewModel(application) {
     private val context get() = getApplication<Application>()
-    private val sharedPref = context.getSharedPreferences(NET_DISCDD_VIEWMODELS_FIRST_OPEN, MODE_PRIVATE)
+    private val sharedPref = context.getSharedPreferences(NET_DISCDD_VIEWMODELS_PREFS, MODE_PRIVATE)
+
     private val _firstOpen = MutableStateFlow(true)
     val firstOpen = _firstOpen.asStateFlow()
 
+    private val _showEasterEgg = MutableStateFlow(false)
+    val showEasterEgg = _showEasterEgg.asStateFlow()
+
     init {
-        val firstOpenCached = sharedPref.getBoolean(NET_DISCDD_VIEWMODELS_FIRST_OPEN, true)
-        _firstOpen.value = firstOpenCached
+        _firstOpen.value = sharedPref.getBoolean(NET_DISCDD_VIEWMODELS_FIRST_OPEN, true)
+        _showEasterEgg.value = sharedPref.getBoolean(NET_DISCDD_VIEWMODELS_SHOW_EASTER_EGG, false)
     }
 
     fun onFirstOpen() {
@@ -24,7 +28,15 @@ class SettingsViewModel(
         sharedPref.edit().putBoolean(NET_DISCDD_VIEWMODELS_FIRST_OPEN, false).apply()
     }
 
+    fun onToggleEasterEgg() {
+        val newValue = !_showEasterEgg.value
+        _showEasterEgg.value = newValue
+        sharedPref.edit().putBoolean(NET_DISCDD_VIEWMODELS_SHOW_EASTER_EGG, newValue).apply()
+    }
+
     companion object {
+        const val NET_DISCDD_VIEWMODELS_PREFS = "net.discdd.viewmodels.PREFS"
         const val NET_DISCDD_VIEWMODELS_FIRST_OPEN: String = "net.discdd.viewmodels.FIRST_OPEN"
+        const val NET_DISCDD_VIEWMODELS_SHOW_EASTER_EGG: String = "net.discdd.viewmodels.SHOW_EASTER_EGG"
     }
 }


### PR DESCRIPTION
- the log/permission screens should really only be shown to developers
- To toggle the easter egg in BundleClient, tap the "client id" label 7 times in < 3 sec!
- TODO: implement for BundleTransport