### PR TITLE
handle wifi permission in transport

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/WifiDirectViewModel.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/WifiDirectViewModel.kt
@@ -16,6 +16,7 @@ import net.discdd.bundleclient.BundleClientServiceBroadcastReceiver
 import net.discdd.bundleclient.BundleClientWifiDirectService
 import net.discdd.bundleclient.R
 import net.discdd.bundleclient.WifiServiceManager
+import net.discdd.viewmodels.RuntimeViewModel
 import java.net.InetAddress
 import java.util.concurrent.CompletableFuture
 
@@ -41,26 +42,18 @@ data class WifiDirectState(
 
 class WifiDirectViewModel(
     application: Application,
-): AndroidViewModel(application) {
-    private val context get() = getApplication<Application>()
+): RuntimeViewModel(application) {
     private val bundleClientServiceBroadcastReceiver = BundleClientServiceBroadcastReceiver().apply {
         setViewModel(this@WifiDirectViewModel)
     }
     private val wifiService by lazy { WifiServiceManager.getService() }
     private val peerDeviceAddresses = ArrayList<String>()
     private val intentFilter = IntentFilter()
-    private val sharedPref = context.getSharedPreferences(NET_DISCDD_BUNDLECLIENT_NUM_DENIED, MODE_PRIVATE)
-
-    private val _numDenied = MutableStateFlow(0)
-    val numDenied = _numDenied.asStateFlow()
 
     private val _state = MutableStateFlow(WifiDirectState())
     val state = _state.asStateFlow()
 
     init {
-        val numDeniedCached = sharedPref.getInt(NET_DISCDD_BUNDLECLIENT_NUM_DENIED, 0)
-        _numDenied.value = numDeniedCached
-
         intentFilter.addAction(BundleClientWifiDirectService.NET_DISCDD_BUNDLECLIENT_WIFI_EVENT_ACTION)
         intentFilter.addAction(BundleClientWifiDirectService.NET_DISCDD_BUNDLECLIENT_LOG_ACTION)
         registerBroadcastReceiver()
@@ -210,15 +203,5 @@ class WifiDirectViewModel(
 
     fun getWifiBgService(): BundleClientWifiDirectService? {
         return wifiService
-    }
-
-    fun incrementNumDenied() {
-        val newNumDenied = _numDenied.value + 1
-        _numDenied.value = newNumDenied
-        sharedPref.edit().putInt(NET_DISCDD_BUNDLECLIENT_NUM_DENIED, newNumDenied).apply()
-    }
-
-    companion object {
-        const val NET_DISCDD_BUNDLECLIENT_NUM_DENIED: String = "net.discdd.bundleclient.NUM_DENIED"
     }
 }

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/ServerUploadScreen.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/ServerUploadScreen.kt
@@ -2,6 +2,7 @@ package net.discdd.bundletransport.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -37,10 +38,10 @@ import net.discdd.viewmodels.SettingsViewModel
 
 @Composable
 fun ServerUploadScreen(
-        uploadViewModel: ServerUploadViewModel = viewModel(),
-        connectivityViewModel: ConnectivityViewModel = viewModel(),
-        settingsViewModel: SettingsViewModel = viewModel(),
-        onToggle: () -> Unit,
+    uploadViewModel: ServerUploadViewModel = viewModel(),
+    connectivityViewModel: ConnectivityViewModel = viewModel(),
+    settingsViewModel: SettingsViewModel = viewModel(),
+    onToggle: () -> Unit,
 ) {
     val uploadState by uploadViewModel.state.collectAsState()
     val connectivityState by connectivityViewModel.state.collectAsState()
@@ -60,43 +61,43 @@ fun ServerUploadScreen(
     }
 
     Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = MaterialTheme.colorScheme.background,
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
     ) {
         Column(
-                modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             FilledTonalButton(
-                    onClick = { uploadViewModel.connectServer() },
-                    enabled = connectServerBtn,
-                    modifier = Modifier.fillMaxWidth()
+                onClick = { uploadViewModel.connectServer() },
+                enabled = connectServerBtn,
+                modifier = Modifier.fillMaxWidth()
             ) {
                 Text("Connect to Bundle Server")
             }
 
             if (showEasterEgg) {
                 OutlinedTextField(
-                        value = uploadState.domain,
-                        onValueChange = { uploadViewModel.onDomainChanged(it) },
-                        label = { Text("Domain Input") },
-                        modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(8.dp),
+                    value = uploadState.domain,
+                    onValueChange = { uploadViewModel.onDomainChanged(it) },
+                    label = { Text("Domain Input") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
                 )
                 OutlinedTextField(
-                        value = uploadState.port,
-                        onValueChange = { uploadViewModel.onPortChanged(it) },
-                        label = { Text("Port Input") },
-                        modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(8.dp),
+                    value = uploadState.port,
+                    onValueChange = { uploadViewModel.onPortChanged(it) },
+                    label = { Text("Port Input") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
                 )
                 FilledTonalButton(
-                        onClick = { uploadViewModel.saveDomainPort() },
-                        modifier = Modifier.fillMaxWidth()
+                    onClick = { uploadViewModel.saveDomainPort() },
+                    modifier = Modifier.fillMaxWidth()
                 ) {
                     Text("Save Domain and Port")
                 }
@@ -109,45 +110,50 @@ fun ServerUploadScreen(
             }
 
             Row(
-                    modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 /*
                 * The "toClient" section is the designated easter egg location for BundleTransport
                 * Click this portion 7 times in <3sec in order to toggle the easter egg!
                 * */
                 EasterEgg(
-                        content = { Text(text = "toClient: ", fontSize = 20.sp) },
-                        onToggle = onToggle,
+                    content = { Text(text = "toClient: ", fontSize = 20.sp) },
+                    onToggle = onToggle,
                 )
                 Text(
-                        text = uploadState.clientCount,
-                        fontSize = 20.sp
+                    text = uploadState.clientCount,
+                    fontSize = 20.sp
                 )
                 Text(
-                        text = "    toServer: ",
-                        fontSize = 20.sp
+                    text = "    toServer: ",
+                    fontSize = 20.sp
                 )
                 Text(
-                        text = uploadState.serverCount,
-                        fontSize = 20.sp
+                    text = uploadState.serverCount,
+                    fontSize = 20.sp
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 FilledTonalButton(
-                        onClick = { uploadViewModel.reloadCount() },
-                        modifier = Modifier.size(70.dp, 50.dp)
+                    onClick = { uploadViewModel.reloadCount() },
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp)
                 ) {
-                    Icon(imageVector = Icons.Default.Refresh, contentDescription = "Reload Counts")
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = "Reload Counts",
+                        modifier = Modifier.size(24.dp)
+                    )
                 }
             }
 
             uploadState.message?.let { message ->
                 Text(
-                        text = message,
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodyMedium
+                    text = message,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium
                 )
             }
         }

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportHomeScreen.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportHomeScreen.kt
@@ -1,5 +1,6 @@
 package net.discdd.bundletransport.screens
 
+import android.Manifest
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,6 +29,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.rememberPermissionState
 import kotlinx.coroutines.launch
 import net.discdd.UsbConnectionManager
 import net.discdd.bundletransport.ConnectivityManager
@@ -45,6 +48,7 @@ data class TabItem(
         val screen: @Composable () -> Unit,
 )
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun TransportHomeScreen(
         viewModel: SettingsViewModel = viewModel()
@@ -55,6 +59,9 @@ fun TransportHomeScreen(
     val showUsbScreen by UsbConnectionManager.usbConnected.collectAsState()
     val showEasterEgg by viewModel.showEasterEgg.collectAsState()
     val internetAvailable by ConnectivityManager.internetAvailable.collectAsState()
+    val nearbyWifiState = rememberPermissionState(
+        Manifest.permission.NEARBY_WIFI_DEVICES
+    )
 
     val standardTabs = remember {
         listOf(
@@ -95,7 +102,8 @@ fun TransportHomeScreen(
             title = context.getString(R.string.local_wifi),
             screen = {
                 WifiDirectScreen(
-                        serviceReadyFuture = TransportWifiServiceManager.serviceReady
+                    serviceReadyFuture = TransportWifiServiceManager.serviceReady,
+                    nearbyWifiState = nearbyWifiState
                 )
             }
     )

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/WifiDirectScreen.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/WifiDirectScreen.kt
@@ -1,7 +1,11 @@
 package net.discdd.bundletransport.screens
 
+import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
+import android.net.Uri
+import android.provider.Settings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -31,33 +35,42 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat.startActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionState
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 import net.discdd.bundletransport.R
 import net.discdd.bundletransport.TransportWifiDirectService
 import net.discdd.bundletransport.viewmodels.WifiDirectViewModel
+import net.discdd.components.WifiPermissionBanner
 import java.util.concurrent.CompletableFuture
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun WifiDirectScreen(
-        wifiViewModel: WifiDirectViewModel = viewModel(),
-        serviceReadyFuture: CompletableFuture<TransportWifiDirectService>,
-        preferences: SharedPreferences = LocalContext.current.getSharedPreferences(
-                TransportWifiDirectService.WIFI_DIRECT_PREFERENCES,
-                Context.MODE_PRIVATE
-        )
+    wifiViewModel: WifiDirectViewModel = viewModel(),
+    serviceReadyFuture: CompletableFuture<TransportWifiDirectService>,
+    nearbyWifiState: PermissionState,
+    preferences: SharedPreferences = LocalContext.current.getSharedPreferences(
+        TransportWifiDirectService.WIFI_DIRECT_PREFERENCES,
+        Context.MODE_PRIVATE
+    )
 ) {
     val state by wifiViewModel.state.collectAsState()
+    val numDenied by wifiViewModel.numDenied.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
     var showDialog by remember { mutableStateOf(false) }
+    val context = LocalContext.current
 
     Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = MaterialTheme.colorScheme.background
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
     ) {
-
         LaunchedEffect(Unit) {
             wifiViewModel.initialize(serviceReadyFuture)
         }
@@ -75,48 +88,62 @@ fun WifiDirectScreen(
         }
 
         Column(
-                modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-
             var checked by remember {
                 mutableStateOf(
-                        preferences.getBoolean(
-                                TransportWifiDirectService.WIFI_DIRECT_PREFERENCE_BG_SERVICE,
-                                true
-                        )
+                    preferences.getBoolean(
+                        TransportWifiDirectService.WIFI_DIRECT_PREFERENCE_BG_SERVICE,
+                        true
+                    )
                 )
             }
-
             val nameValid by remember {
                 derivedStateOf { state.deviceName.startsWith("ddd_") }
             }
 
+            if (!nearbyWifiState.status.isGranted) {
+                WifiPermissionBanner(numDenied, nearbyWifiState) {
+                    // if user denies access twice, manual access in settings is required
+                    if (numDenied >= 2) {
+                        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                            data = Uri.fromParts("package", context.packageName, null)
+                        }
+                        startActivity(context, intent, null)
+                    } else {
+                        wifiViewModel.incrementNumDenied()
+                        nearbyWifiState.launchPermissionRequest()
+                    }
+                }
+            }
+
             Text(
-                    text = state.wifiInfo,
-                    modifier = Modifier.clickable { showDialog = true }
+                text = state.wifiInfo,
+                modifier = Modifier.clickable { showDialog = true }
             )
+
             if (showDialog == true) {
-                var gi = wifiViewModel.getService()?.groupInfo
-                var connectedPeers: ArrayList<String> = ArrayList<String>()
-                if (gi != null) {
+                val connectedPeers: ArrayList<String> = ArrayList()
+                wifiViewModel.getService()?.groupInfo?.let { gi ->
                     gi.clientList.forEach { c -> connectedPeers.add(c.deviceName) }
                 }
+
                 AlertDialog(
-                        title = { Text(text = stringResource(R.string.connected_devices)) },
-                        text = { Text(text = connectedPeers.toTypedArray().joinToString(", ")) },
-                        onDismissRequest = { showDialog = false },
-                        confirmButton = {
-                            TextButton(
-                                    onClick = {
-                                        showDialog = false
-                                    }
-                            ) {
-                                Text(stringResource(R.string.dismiss))
+                    title = { Text(text = stringResource(R.string.connected_devices)) },
+                    text = { Text(text = connectedPeers.toTypedArray().joinToString(", ")) },
+                    onDismissRequest = { showDialog = false },
+                    confirmButton = {
+                        TextButton(
+                            onClick = {
+                                showDialog = false
                             }
+                        ) {
+                            Text(stringResource(R.string.dismiss))
                         }
+                    }
                 )
             }
 
@@ -124,17 +151,17 @@ fun WifiDirectScreen(
             Text(text = "Device Name: ${state.deviceName}")
 
             Row(
-                    verticalAlignment = Alignment.CenterVertically,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Checkbox(
-                        checked = checked,
-                        onCheckedChange = {
-                            checked = it
-                            preferences.edit().putBoolean(
-                                    TransportWifiDirectService.WIFI_DIRECT_PREFERENCE_BG_SERVICE,
-                                    it
-                            ).apply()
-                        }
+                    checked = checked,
+                    onCheckedChange = {
+                        checked = it
+                        preferences.edit().putBoolean(
+                            TransportWifiDirectService.WIFI_DIRECT_PREFERENCE_BG_SERVICE,
+                            it
+                        ).apply()
+                    }
                 )
                 Text(text = stringResource(R.string.collect_data_even_when_app_is_closed))
             }
@@ -145,8 +172,9 @@ fun WifiDirectScreen(
                 Text(text = stringResource(R.string.phone_name_must_start_with_ddd))
 
                 FilledTonalButton(
-                        onClick = { wifiViewModel.openInfoSettings() },
-                        modifier = Modifier.fillMaxWidth()) {
+                    onClick = { wifiViewModel.openInfoSettings() },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
                     Text(stringResource(R.string.change_phone_name))
                 }
             }
@@ -158,8 +186,13 @@ fun WifiDirectScreen(
 }
 
 @Preview(showBackground = true)
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun WifiDirectScreenPreview() {
-    WifiDirectScreen(serviceReadyFuture = CompletableFuture())
+    val nearbyWifiState = rememberPermissionState(Manifest.permission.NEARBY_WIFI_DEVICES)
+    WifiDirectScreen(
+        serviceReadyFuture = CompletableFuture(),
+        nearbyWifiState = nearbyWifiState
+    )
 }
 

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/WifiDirectViewModel.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/WifiDirectViewModel.kt
@@ -19,6 +19,7 @@ import net.discdd.bundletransport.R
 import net.discdd.bundletransport.TransportWifiDirectService
 import net.discdd.bundletransport.TransportWifiServiceManager
 import net.discdd.pathutils.TransportPaths
+import net.discdd.viewmodels.RuntimeViewModel
 import net.discdd.wifidirect.WifiDirectManager.WifiDirectStatus
 
 import java.net.Inet4Address
@@ -37,8 +38,7 @@ data class WifiDirectState(
 
 class WifiDirectViewModel(
         application: Application
-) : AndroidViewModel(application) {
-    private val context get() = getApplication<Application>()
+) : RuntimeViewModel(application) {
     private val logger = Logger.getLogger(WifiDirectViewModel::class.java.name)
     private val intentFilter = IntentFilter()
     private val bundleTransportWifiEvent = BundleTransportWifiEvent().apply {

--- a/android-core/src/main/java/net/discdd/viewmodels/RuntimeViewModel.kt
+++ b/android-core/src/main/java/net/discdd/viewmodels/RuntimeViewModel.kt
@@ -1,0 +1,36 @@
+package net.discdd.viewmodels
+
+import android.app.Application
+import android.content.Context.MODE_PRIVATE
+import androidx.lifecycle.AndroidViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/*
+Viewmodels for screens that require functionality to NEARBY_WIFI_DEVICES will extend this class.
+Ensure that the screens include the WifiPermissionBanner which prompts the user to grant access.
+This class keeps track of number of time users deny the permission in order to manipulate the UI/UX to grant the permission.
+*/
+open class RuntimeViewModel(
+    application: Application
+): AndroidViewModel(application) {
+    protected val context get() = getApplication<Application>()
+    private val sharedPref = context.getSharedPreferences(NET_DISCDD_BUNDLECLIENT_NUM_DENIED, MODE_PRIVATE)
+    private val _numDenied = MutableStateFlow(0)
+    val numDenied = _numDenied.asStateFlow()
+
+    init {
+        val numDeniedCached = sharedPref.getInt(NET_DISCDD_BUNDLECLIENT_NUM_DENIED, 0)
+        _numDenied.value = numDeniedCached
+    }
+
+    fun incrementNumDenied() {
+        val newNumDenied = _numDenied.value + 1
+        _numDenied.value = newNumDenied
+        sharedPref.edit().putInt(NET_DISCDD_BUNDLECLIENT_NUM_DENIED, newNumDenied).apply()
+    }
+
+    companion object {
+        const val NET_DISCDD_BUNDLECLIENT_NUM_DENIED: String = "net.discdd.bundleclient.NUM_DENIED"
+    }
+}


### PR DESCRIPTION
Add the `WifiPermissionBanner` in BundleTransport. I moved the logic that counts the number of times a user denies runtime permissions into it's own class so I can reuse the logic with inheritance.