### PR TITLE
append server exchange results in BundleClient

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/ServerScreen.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/ServerScreen.kt
@@ -47,12 +47,6 @@ fun ServerScreen(
         val enable = serverState.domain.isNotEmpty() && serverState.port.isNotEmpty() && connectivityState.networkConnected
         enableConnectBtn = enable
     }
-    LaunchedEffect(serverState.message) {
-        if (serverState.message != null) {
-            delay(2000)
-            serverViewModel.clearMessage()
-        }
-    }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -121,6 +115,13 @@ fun ServerScreen(
                 ) {
                     Text("Connect to Bundle Server")
                 }
+            }
+            serverState.message?.let { message ->
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium
+                )
             }
         }
     }

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/ServerViewModel.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/ServerViewModel.kt
@@ -44,27 +44,32 @@ class ServerViewModel(
         _state.update { it.copy(message = null) }
     }
 
+    fun appendMessage(message: String) {
+        _state.update { current ->
+            val currentLines = current.message?.split("\n")?.takeLast(10) ?: emptyList()
+            val newLines = (currentLines + message)
+            current.copy(message = newLines.joinToString("\n"))
+        }
+    }
+
     fun connectServer() {
         viewModelScope.launch {
             try {
-                _state.update {
-                    it.copy(message = context.getString(R.string.connecting_to_server))
-                }
+                appendMessage(context.getString(R.string.connecting_to_server))
                 val wifiBgService = WifiServiceManager.getService()
                 wifiBgService?.let { service ->
                     service.initiateServerExchange()
                         .thenAccept { bec ->
-                            _state.update { it.copy(message = context.getString(
+                            appendMessage(context.getString(
                                 R.string.upload_status,
                                 bec.uploadStatus(),
                                 bec.downloadStatus()
                             )) }
-                        }
-                } ?: run {
-                    _state.update { it.copy(message = context.getString(R.string.service_not_available)) }
+                        } ?: run {
+                    appendMessage(context.getString(R.string.service_not_available))
                 }
             } catch (e : Exception) {
-                _state.update { it.copy(message = context.getString(R.string.service_not_available)) }
+                appendMessage(context.getString(R.string.service_not_available))
             }
         }
     }
@@ -84,7 +89,7 @@ class ServerViewModel(
                 .putString("domain", state.value.domain)
                 .putInt("port", state.value.port.toInt())
                 .apply()
-            _state.update { it.copy(message = context.getString(R.string.settings_saved)) }
+            appendMessage(context.getString(R.string.settings_saved))
         }
     }
 }


### PR DESCRIPTION
the messages showing the progress of the server exchange is important for the UX. the messages text box is no longer hidden by the easter egg. messages append to the results rather than replace.