### PR TITLE
BundleTransport return NOT_FOUND for no bundle

### DIFF
--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/RpcServer.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/RpcServer.java
@@ -77,9 +77,12 @@ public class RpcServer {
             protected Path pathProducer(BundleExchangeName bundleExchangeName,
                                         BundleSenderType bundleSenderType,
                                         PublicKeyMap publicKeyMap) {
-                return bundleExchangeName.isDownload() ?
-                       toClientPath.resolve(bundleExchangeName.encryptedBundleId()) :
-                       toServerPath.resolve(bundleExchangeName.encryptedBundleId());
+                if (bundleExchangeName.isDownload()) {
+                    var path = toClientPath.resolve(bundleExchangeName.encryptedBundleId());
+                    return Files.exists(path) ? path : null;
+                } else {
+                    return toServerPath.resolve(bundleExchangeName.encryptedBundleId());
+                }
             }
 
             @Override


### PR DESCRIPTION
if the BundleTransport doesn't have a bundle that the client requests, return a NOT_FOUND exception.