### PR TITLE
Use a single threaded executor in BundleClient

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientWifiDirectService.java
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientWifiDirectService.java
@@ -61,7 +61,7 @@ public class BundleClientWifiDirectService extends Service implements WifiDirect
     private static SharedPreferences preferences;
     final AtomicReference<CompletableFuture<WifiP2pGroup>> connectionWaiter = new AtomicReference<>();
     private final IBinder binder = new BundleClientWifiDirectServiceBinder();
-    private final ScheduledExecutorService periodicExecutor = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService periodicExecutor = Executors.newSingleThreadScheduledExecutor();
     PeriodicRunnable periodicRunnable = new PeriodicRunnable();
     private WifiDirectManager wifiDirectManager;
     private BundleTransmission bundleTransmission;


### PR DESCRIPTION
We assume the tasks submitted are executed in sequence, so we need a single threaded executor.