### PR TITLE
BundleClient registers broadcast receiver once

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/WifiDirectViewModel.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/WifiDirectViewModel.kt
@@ -54,7 +54,6 @@ class WifiDirectViewModel(
     init {
         intentFilter.addAction(BundleClientWifiDirectService.NET_DISCDD_BUNDLECLIENT_WIFI_EVENT_ACTION)
         intentFilter.addAction(BundleClientWifiDirectService.NET_DISCDD_BUNDLECLIENT_LOG_ACTION)
-        registerBroadcastReceiver()
     }
 
     fun initialize(serviceReadyFuture: CompletableFuture<BundleClientWifiDirectService>) {


### PR DESCRIPTION
broadcast receivers should only be registered and unregistered on PAUSE an RESUME to make sure it's only registered once.