### PR TITLE
track discovery active with a boolean in BundleClient

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/WifiDirectScreen.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/WifiDirectScreen.kt
@@ -143,6 +143,14 @@ fun WifiDirectScreen(
                 onToggle = onToggle,
             )
             Text(text = "Connected Device Addresses: ${state.connectedDeviceText}")
+            Text(
+                text = "Discovery Status: ${
+                    if (state.discoveryActive) {
+                        "Active"
+                    } else "Inactive"
+                }"
+            )
+
             var checked by remember {
                 mutableStateOf(
                     preferences.getBoolean(
@@ -164,14 +172,6 @@ fun WifiDirectScreen(
                         ).apply()
                     }
                 )
-                Text(
-                    text = "Discovery Status: ${
-                        if (state.discoveryActive) {
-                            "Active"
-                        } else "Inactive"
-                    }"
-                )
-
                 Text(text = "Do transfers in the background")
 
                 IconButton(

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/WifiDirectScreen.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/WifiDirectScreen.kt
@@ -143,7 +143,6 @@ fun WifiDirectScreen(
                 onToggle = onToggle,
             )
             Text(text = "Connected Device Addresses: ${state.connectedDeviceText}")
-            Text(text = "Discovery Status: ${state.deliveryStatus}")
             var checked by remember {
                 mutableStateOf(
                     preferences.getBoolean(
@@ -164,6 +163,13 @@ fun WifiDirectScreen(
                             it
                         ).apply()
                     }
+                )
+                Text(
+                    text = "Discovery Status: ${
+                        if (state.discoveryActive) {
+                            "Active"
+                        } else "Inactive"
+                    }"
                 )
 
                 Text(text = "Do transfers in the background")

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/WifiDirectViewModel.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/WifiDirectViewModel.kt
@@ -30,7 +30,7 @@ data class PeerDevice(
 data class WifiDirectState(
     val resultText: String = "",
     val connectedDeviceText: String = "",
-    val deliveryStatus: String = "",
+    val discoveryActive: Boolean = false,
     val clientId: String = "Service not running",
     val backgroundExchange: Boolean = false,
     val peers: List<PeerDevice> = emptyList(),
@@ -63,7 +63,7 @@ class WifiDirectViewModel(
                 _state.update {
                     it.copy(
                         clientId = service.clientId,
-                        deliveryStatus = if (service.isDiscoveryActive) "Active" else "Inactive"
+                        discoveryActive = service?.isDiscoveryActive ?: false
                     )
                 }
             }
@@ -144,7 +144,7 @@ class WifiDirectViewModel(
 
     fun updateDeliveryStatus() {
         _state.update {
-            it.copy(deliveryStatus = if (wifiService?.isDiscoveryActive == true) "Active" else "Inactive")
+            it.copy(discoveryActive = wifiService?.isDiscoveryActive ?: false)
         }
     }
 


### PR DESCRIPTION
Tracking discovery active with a boolean rather than a string allows clearer logic to check active discovery.