### PR TITLE
preserve peers in BundleClient

### DIFF
--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/WifiDirectViewModel.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/WifiDirectViewModel.kt
@@ -167,13 +167,25 @@ class WifiDirectViewModel(
             val updatedPeers = peerDeviceAddresses.mapNotNull { deviceAddress ->
                 val peer = wifiService?.getPeer(deviceAddress)
                 if (peer != null) {
-                    PeerDevice(
-                        deviceAddress = deviceAddress,
-                        deviceName = peer.deviceName,
-                        lastSeen = peer.lastSeen,
-                        lastExchange = peer.lastExchange,
-                        recencyTime = peer.recencyTime
-                    )
+                    val currentPeer = _state.value.peers.find { it.deviceAddress == deviceAddress }
+                    if (currentPeer != null) {
+                        // Update existing peer
+                        currentPeer.copy(
+                            deviceName = peer.deviceName,
+                            lastSeen = peer.lastSeen,
+                            lastExchange = peer.lastExchange,
+                            recencyTime = peer.recencyTime
+                        )
+                    } else {
+                        // Create new peer
+                        PeerDevice(
+                            deviceAddress = deviceAddress,
+                            deviceName = peer.deviceName,
+                            lastSeen = peer.lastSeen,
+                            lastExchange = peer.lastExchange,
+                            recencyTime = peer.recencyTime
+                        )
+                    }
                 } else {
                     null
                 }


### PR DESCRIPTION
when processing discovered peers. preserve the PeerDevice objects that we already know about. this ensures that things like isExchangeInProgress are preserved.