### PR TITLE
display a substring of the bundle transport id

### DIFF
--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/ServerUploadScreen.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/ServerUploadScreen.kt
@@ -81,6 +81,9 @@ fun ServerUploadScreen(
                         },
                 verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            Text(
+                    text = "TransportId: ${uploadViewModel.transportID.slice(4..20)}",
+            )
             FilledTonalButton(
                     onClick = { uploadViewModel.connectServer() },
                     enabled = connectServerBtn,

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/ServerUploadViewModel.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/ServerUploadViewModel.kt
@@ -30,19 +30,20 @@ data class ServerState(
 class ServerUploadViewModel(
         application: Application
 ) : AndroidViewModel(application) {
+    public val transportID: String
     private val context get() = getApplication<Application>()
     private val sharedPref = context.getSharedPreferences("server_endpoint", MODE_PRIVATE)
     private val logger = Logger.getLogger(ServerUploadViewModel::class.java.name)
     private val _state = MutableStateFlow(ServerState())
     private val executor: ExecutorService = Executors.newFixedThreadPool(2);
     private var transportPaths: TransportPaths = TransportPaths(context.getExternalFilesDir(null)?.toPath())
-    private var transportID: String? = ""
     private val transportGrpcSecurity = GrpcSecurityHolder.setGrpcSecurityHolder(transportPaths.grpcSecurityPath);
     val state = _state.asStateFlow()
 
     init {
+        val publicKey = transportGrpcSecurity.grpcKeyPair.public.encoded
         transportID = Base64.getEncoder().encodeToString(
-                transportGrpcSecurity.grpcKeyPair.public.encoded
+            publicKey
         )
         AndroidAppConstants.checkDefaultDomainPortSettings(sharedPref)
         restoreDomainPort()


### PR DESCRIPTION
the bundle transport id is long, so display a substring on the UI. this will allow us to diagnose transport issues if they come up.