### PR TITLE
enable disconnected client app install from transport

### DIFF
--- a/BundleTransport/app/build.gradle
+++ b/BundleTransport/app/build.gradle
@@ -98,6 +98,9 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.8.2'
     implementation 'com.google.android.material:material:1.12.0'
 
+    implementation "com.google.zxing:core:3.5.1"
+    implementation 'org.nanohttpd:nanohttpd:2.3.1'
+
     testImplementation 'junit:junit:4.+'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/FileHttpServer.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/FileHttpServer.java
@@ -1,15 +1,10 @@
 package net.discdd.bundletransport;
 
-import android.content.Context;
-import android.util.Log;
-
 import fi.iki.elonen.NanoHTTPD;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Map;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.INFO;
@@ -35,24 +30,41 @@ public class FileHttpServer extends NanoHTTPD {
             if (file.exists()) {
                 try {
                     FileInputStream fis = new FileInputStream(file);
-                    return newChunkedResponse(Response.Status.OK,
-                                              getMimeTypeForFile(uri), fis);
+                    return newChunkedResponse(Response.Status.OK, getMimeTypeForFile(uri), fis);
                 } catch (FileNotFoundException e) {
                     logger.log(SEVERE, "File not found: " + file.getAbsolutePath(), e);
-                    return newFixedLengthResponse(Response.Status.NOT_FOUND,
-                                                  MIME_PLAINTEXT, "File not found");
+                    return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "File not found");
                 }
             } else {
-                return newFixedLengthResponse(Response.Status.NOT_FOUND,
-                                              MIME_PLAINTEXT, "File not found");
+                return newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "File not found");
             }
         } else {
             // Serve a simple HTML index page
             StringBuilder html = new StringBuilder();
-            html.append("<html><body>");
-            html.append("<h1>DDD File Server</h1>");
-            html.append("<p>Available files:</p>");
-            html.append("<ul>");
+            html.append("""
+                                <html><head>
+                                <meta charset="UTF-8">
+                                <meta name="viewport" content="width=device-width, initial-scale=1">
+                                <title>DDD App Share</title>
+                                 <style>
+                                    body {
+                                      font-family: sans-serif;
+                                      font-size: 1.7rem;
+                                      line-height: 1.5;
+                                    }
+                                    h1 {
+                                      font-size: 2rem;
+                                      margin-bottom: 0.5rem;
+                                    }
+                                    ul {
+                                      padding-left: 1.2rem;
+                                      line-height: 1.7;
+                                    }
+                                  </style>
+                                <body>
+                                <h1>DDD App Share</h1>
+                                <p>Available apps:</p>
+                                <ul>""");
             File mailApk = new File(filesDir, "ddd-mail.apk");
             File clientApk = new File(filesDir, "DDDClient.apk");
 
@@ -65,7 +77,6 @@ public class FileHttpServer extends NanoHTTPD {
             }
 
             html.append("</ul></body></html>");
-
             return newFixedLengthResponse(html.toString());
         }
     }

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/FileHttpServer.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/FileHttpServer.java
@@ -1,0 +1,72 @@
+package net.discdd.bundletransport;
+
+import android.content.Context;
+import android.util.Log;
+
+import fi.iki.elonen.NanoHTTPD;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+
+public class FileHttpServer extends NanoHTTPD {
+    private static final Logger logger = Logger.getLogger(FileHttpServer.class.getName());
+    private final File filesDir;
+
+    public FileHttpServer(int port, File filesDir) {
+        super(port);
+        this.filesDir = filesDir;
+    }
+
+    @Override
+    public Response serve(IHTTPSession session) {
+        String uri = session.getUri();
+        logger.log(INFO, "Serving request: " + uri);
+
+        // For security, restrict access to only the APK files
+        if (uri.equals("/ddd-mail.apk") || uri.equals("/DDDClient.apk")) {
+            File file = new File(filesDir, uri.substring(1));
+            if (file.exists()) {
+                try {
+                    FileInputStream fis = new FileInputStream(file);
+                    return newChunkedResponse(Response.Status.OK,
+                                              getMimeTypeForFile(uri), fis);
+                } catch (FileNotFoundException e) {
+                    logger.log(SEVERE, "File not found: " + file.getAbsolutePath(), e);
+                    return newFixedLengthResponse(Response.Status.NOT_FOUND,
+                                                  MIME_PLAINTEXT, "File not found");
+                }
+            } else {
+                return newFixedLengthResponse(Response.Status.NOT_FOUND,
+                                              MIME_PLAINTEXT, "File not found");
+            }
+        } else {
+            // Serve a simple HTML index page
+            StringBuilder html = new StringBuilder();
+            html.append("<html><body>");
+            html.append("<h1>DDD File Server</h1>");
+            html.append("<p>Available files:</p>");
+            html.append("<ul>");
+            File mailApk = new File(filesDir, "ddd-mail.apk");
+            File clientApk = new File(filesDir, "DDDClient.apk");
+
+            if (mailApk.exists()) {
+                html.append("<li><a href='/ddd-mail.apk'>DDD Mail App</a></li>");
+            }
+
+            if (clientApk.exists()) {
+                html.append("<li><a href='/DDDClient.apk'>DDD Client App</a></li>");
+            }
+
+            html.append("</ul></body></html>");
+
+            return newFixedLengthResponse(html.toString());
+        }
+    }
+}

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/AppShareScreen.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/AppShareScreen.kt
@@ -1,0 +1,250 @@
+package net.discdd.bundletransport.screens
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.WriterException
+import com.google.zxing.qrcode.QRCodeWriter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+@Composable
+fun AppShareScreen() {
+    val url = "http://192.168.49.1:8080"
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    // APK URLs
+    val mailApkUrl =
+        "https://github.com/SJSU-CS-systems-group/DDD-thunderbird-android/releases/latest/download/ddd-mail.apk"
+    val clientApkUrl = "https://github.com/SJSU-CS-systems-group/DDD/releases/latest/download/DDDClient.apk"
+    val mailApkFile = File(context.getExternalFilesDir(null), "ddd-mail.apk")
+    val clientApkFile = File(context.getExternalFilesDir(null), "DDDClient.apk")
+    var filesDownloaded by remember { mutableStateOf(mailApkFile.exists() && clientApkFile.exists()) }
+    var mailApkVersion by remember { mutableStateOf(getApkVersionInfo(context, mailApkFile))}
+    var clientApkVersion by remember { mutableStateOf(getApkVersionInfo(context, clientApkFile))}
+
+    // Download states
+    var isDownloadingMail by remember { mutableStateOf(false) }
+    var isDownloadingClient by remember { mutableStateOf(false) }
+    var downloadMailProgress by remember { mutableStateOf(0f) }
+    var downloadClientProgress by remember { mutableStateOf(0f) }
+    var downloadMailStatus by remember { mutableStateOf(getApkStatus(context, mailApkFile)) }
+    var downloadClientStatus by remember { mutableStateOf(getApkStatus(context, clientApkFile)) }
+
+    // Generate QR code bitmap
+    val qrBitmap = remember {
+        generateQRCode(url, 300, 300)
+    }
+
+    Surface(color = MaterialTheme.colorScheme.background) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Show either download message or QR code
+            if (!filesDownloaded) {
+                Text(
+                    text = "Download APK files first to enable app sharing",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+            } else {
+                Text(
+                    text = "Scan QR code to share DDD client and mail apps",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+
+                qrBitmap?.let {
+                    Image(
+                        bitmap = it.asImageBitmap(), contentDescription = "QR Code", modifier = Modifier.size(250.dp)
+                    )
+                }
+
+                Text(
+                    text = url, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(top = 16.dp)
+                )
+            }
+
+            Button(
+                onClick = {
+                    isDownloadingMail = true
+                    isDownloadingClient = true
+                    scope.launch {
+                        try {
+                            val result = downloadFile(
+                                context,
+                                mailApkUrl,
+                            ) { progress ->
+                                downloadMailProgress = progress
+                            }
+                            val versionInfo = getApkVersionInfo(context, result)
+                        } catch (e: Exception) {
+                            downloadMailStatus = "Error: ${e.message}"
+                        } finally {
+                            isDownloadingMail = false
+                        }
+                    }
+                    scope.launch {
+                        try {
+                            val result = downloadFile(
+                                context,
+                                clientApkUrl,
+                            ) { progress ->
+                                downloadClientProgress = progress
+                            }
+                            val versionInfo = getApkVersionInfo(context, result)
+                        } catch (e: Exception) {
+                            downloadClientStatus = "Error: ${e.message}"
+                        } finally {
+                            isDownloadingClient = false
+                        }
+                    }
+                }, enabled = !isDownloadingMail && !isDownloadingClient
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(Icons.Default.ArrowDropDown, contentDescription = "Download")
+                    Text("Download DDD APKs")
+                }
+            }
+
+            if (isDownloadingMail) {
+                LinearProgressIndicator(
+                    progress = { downloadMailProgress }, modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+                )
+            } else {
+                Text(
+                    text = downloadMailStatus,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (downloadMailStatus.contains("Error")) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+                )
+            }
+
+            if (isDownloadingClient) {
+                LinearProgressIndicator(
+                    progress = { downloadClientProgress }, modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+                )
+            } else {
+                Text(
+                    text = downloadClientStatus,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (downloadClientStatus.contains("Error")) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+    }
+}
+
+fun generateQRCode(content: String, width: Int, height: Int): Bitmap? {
+    return try {
+        val qrCodeWriter = QRCodeWriter()
+        val bitMatrix = qrCodeWriter.encode(content, BarcodeFormat.QR_CODE, width, height)
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565)
+
+        for (x in 0 until width) {
+            for (y in 0 until height) {
+                bitmap.setPixel(
+                    x, y, if (bitMatrix[x, y]) Color.BLACK else Color.WHITE
+                )
+            }
+        }
+
+        bitmap
+    } catch (e: WriterException) {
+        null
+    }
+}
+
+suspend fun downloadFile(
+    context: Context, url: String, onProgress: (Float) -> Unit
+): File = withContext(Dispatchers.IO) {
+    var connection: HttpURLConnection? = null
+    try {
+        val fileName = url.substringAfterLast('/')
+        connection = URL(url).openConnection() as HttpURLConnection
+        connection.connect()
+
+        val fileLength = connection.contentLength
+        val inputStream = connection.inputStream
+        val destinationDir = context.getExternalFilesDir(null)
+        val file = File(destinationDir, fileName)
+
+        // Delete the file if it already exists
+        if (file.exists()) {
+            file.delete()
+        }
+
+        // Create parent directories if they don't exist
+        file.parentFile?.mkdirs()
+
+        FileOutputStream(file).use { output ->
+            val buffer = ByteArray(4 * 1024) // 4KB buffer
+            var downloadedSize = 0
+            var bytesRead: Int
+
+            while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                output.write(buffer, 0, bytesRead)
+                downloadedSize += bytesRead
+
+                if (fileLength > 0) {
+                    val progress = downloadedSize.toFloat() / fileLength.toFloat()
+                    withContext(Dispatchers.Main) {
+                        onProgress(progress)
+                    }
+                }
+            }
+
+            output.flush()
+        }
+
+        file
+    } finally {
+        connection?.disconnect()
+    }
+}
+
+fun getApkVersionInfo(context: Context, apkFile: File): Pair<String, Int>? {
+    val packageManager = context.packageManager
+    val packageInfo = packageManager.getPackageArchiveInfo(
+        apkFile.absolutePath, PackageManager.GET_ACTIVITIES
+    )
+
+    return if (packageInfo != null) {
+        Pair(packageInfo.versionName ?: "Unknown", packageInfo.versionCode)
+    } else {
+        null
+    }
+}
+
+fun getApkStatus(context: Context, apkFile: File): String {
+    if (!apkFile.exists()) {
+        return "${apkFile.name} is missing"
+    }
+    val versionInfo = getApkVersionInfo(context, apkFile)
+    return if (versionInfo == null) {
+        "${apkFile.name} is corrupt. Please download again."
+    } else {
+        "${apkFile.name} version ${versionInfo?.first ?: "Unknown"}"
+    }
+}

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportHomeScreen.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportHomeScreen.kt
@@ -85,6 +85,10 @@ fun TransportHomeScreen(
                             StorageScreen()
                         }
                 ),
+                TabItem(
+                        title = "App Share",
+                        screen = { AppShareScreen() }
+                ),
         )
     }
 


### PR DESCRIPTION
since a phone in a disconnected area cannot install the APKs from the internet, we need a way for disconnected users to install the client and mail apps from the transport.
* embeds a simple http server into the background service.
* the UI displays a QR code for easy download of APKs.
* the UI also allows the transport owner to download the latest APKs from the internet.