### PR TITLE
open permissions on MessageProvider

### DIFF
--- a/BundleClient/app/src/main/AndroidManifest.xml
+++ b/BundleClient/app/src/main/AndroidManifest.xml
@@ -34,11 +34,7 @@
         <provider
             android:name="net.discdd.datastore.providers.MessageProvider"
             android:authorities="net.discdd.provider.datastoreprovider"
-            android:exported="true"
-            android:multiprocess="true"
-            android:grantUriPermissions="true"
-            android:writePermission="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_WRITE"
-            android:readPermission="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_READ">
+            android:exported="true">
         </provider>
     </application>
 

--- a/BundleClient/app/src/main/java/net/discdd/datastore/providers/MessageProvider.java
+++ b/BundleClient/app/src/main/java/net/discdd/datastore/providers/MessageProvider.java
@@ -45,6 +45,14 @@ public class MessageProvider extends ContentProvider {
         return getContext().getPackageManager().getNameForUid(receiverId);
     }
 
+    private void checkCallerAppId() throws SecurityException {
+        try {
+            if (getCallerAppId().startsWith("net.discdd.")) return;
+        } catch (IOException e) {
+            logger.log(WARNING, "Unable to get caller app ID", e);
+        }
+        throw new SecurityException("not on the list!");
+    }
     @Override
     public boolean onCreate() {
         var appRootDataDir = Paths.get(getContext().getApplicationInfo().dataDir);
@@ -59,8 +67,9 @@ public class MessageProvider extends ContentProvider {
             @NonNull Uri uri,
             @Nullable String[] projection,
             @Nullable String selection, @Nullable String[] selectionArgs, @Nullable String sortOrder) {
-        MatrixCursor cursor = new MatrixCursor(new String[] { "data", "id", "offset", "exception" });
+        checkCallerAppId();
 
+        MatrixCursor cursor = new MatrixCursor(new String[] { "data", "id", "offset", "exception" });
 
         try {
             String appId = getCallerAppId();
@@ -117,6 +126,7 @@ public class MessageProvider extends ContentProvider {
     @Nullable
     @Override
     public Uri insert(@NonNull Uri uri, @Nullable ContentValues contentValues) {
+        checkCallerAppId();
         try {
             String appName = getCallerAppId();
             byte[] data = contentValues.getAsByteArray("data");
@@ -136,6 +146,8 @@ public class MessageProvider extends ContentProvider {
     @Override
     public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
         String appName;
+        checkCallerAppId();
+
         try {
             appName = getCallerAppId();
         } catch (IOException e) {
@@ -161,7 +173,7 @@ public class MessageProvider extends ContentProvider {
             @NonNull Uri uri,
             @Nullable ContentValues contentValues, @Nullable String selection, @Nullable String[] selectionArgs) {
         int rowsUpdated = 0;
-
+        checkCallerAppId();
         // TODO: implement update if necessary
 
         // getContentResolver provides access to the content model


### PR DESCRIPTION
the custom message provider causes a problem if an app is installed before BundleClient. this removes the custom permissions and checks the calling apps id instead.