### PR TITLE
new ADU notifications through DDDClientAdapter 0.2.0

### DIFF
--- a/BundleClient/app/src/androidTest/java/net/discdd/bundleclient/MessageProviderTest.java
+++ b/BundleClient/app/src/androidTest/java/net/discdd/bundleclient/MessageProviderTest.java
@@ -46,8 +46,7 @@ public class MessageProviderTest {
     public void setUp() throws IOException {
         MessageProvider messageProvider = new MessageProvider();
         messageProvider.attachInfo(ApplicationProvider.getApplicationContext(), null);
-        adapter = new DDDClientAdapter(ApplicationProvider.getApplicationContext(),
-                                       NULL_LIFECYCLE, null);
+        adapter = new DDDClientAdapter(ApplicationProvider.getApplicationContext(), null);
         // access the private sendADUsStorage and receiveADUsStorage fields in messageProvider
         String appId = ApplicationProvider.getApplicationContext().getPackageName();
         sendADUStorePath = ApplicationProvider.getApplicationContext().getDataDir().toPath().resolve("send").resolve(appId);

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/BundleManagerViewModel.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/BundleManagerViewModel.kt
@@ -37,24 +37,24 @@ class BundleManagerViewModel(
     fun getADUcount(ADUPath: Path?): String {
         ADUPath ?: "0"
         try {
-            val stream = Files.newDirectoryStream(ADUPath)
-            for (path in stream) {
-                if (path.fileName.toString().equals("net.discdd.k9")) {
-                    // check for "metadata.json" and exclude it
-                    if (path.toFile().isDirectory()) {
-                        // Get the list of files and exclude "metadata.json"
-                        val filteredFiles =
-                            path.toFile().listFiles {dir, name -> name != "metadata.json" }
-                                ?.map { it.name }?.toTypedArray() ?: emptyArray()
-                        if (filteredFiles.isNullOrEmpty())
-                            return "0"
-                        return filteredFiles.size.toString()
+            Files.newDirectoryStream(ADUPath).use { stream ->
+                for (path in stream) {
+                    if (path.fileName.toString().equals("net.discdd.k9")) {
+                        // check for "metadata.json" and exclude it
+                        if (path.toFile().isDirectory()) {
+                            // Get the list of files and exclude "metadata.json"
+                            val filteredFiles =
+                                path.toFile().listFiles { dir, name -> name != "metadata.json" }
+                                    ?.map { it.name }?.toTypedArray() ?: emptyArray()
+                            if (filteredFiles.isNullOrEmpty())
+                                return "0"
+                            return filteredFiles.size.toString()
+                        }
+                        return path.toFile().list()?.size?.toString() ?: "0"
                     }
-                    return path.toFile().list()?.size?.toString() ?: "0"
                 }
             }
-        }
-        catch (e : Exception) {
+        } catch (e : Exception) {
             when (e) {
                 is IOException, is DirectoryIteratorException -> {
                     System.err.println("Error reading the directory: ${e.message}");

--- a/BundleClient/app/src/main/java/net/discdd/datastore/providers/MessageProvider.java
+++ b/BundleClient/app/src/main/java/net/discdd/datastore/providers/MessageProvider.java
@@ -29,7 +29,7 @@ public class MessageProvider extends ContentProvider {
 
     private static final Logger logger = Logger.getLogger(MessageProvider.class.getName());
     public static final String PROVIDER_NAME = "net.discdd.provider.datastoreprovider";
-    public static final String URL = "content://" + PROVIDER_NAME + "/messages";
+    public static final Uri URL = Uri.parse("content://" +  PROVIDER_NAME + "/messages");
     public static final int MAX_ADU_SIZE = 512*1024;
 
     private StoreADUs sendADUsStorage;
@@ -164,7 +164,6 @@ public class MessageProvider extends ContentProvider {
             if ("deleteAllADUsUpto".equals(selection) && selectionArgs != null && selectionArgs.length == 1) {
                 long lastProcessedADUId = Long.parseLong(selectionArgs[0]);
                 receiveADUsStorage.deleteAllFilesUpTo(null, appName, lastProcessedADUId);
-                getContext().getContentResolver().notifyChange(uri, null);
                 return 1;
             }
             return 0;
@@ -181,10 +180,6 @@ public class MessageProvider extends ContentProvider {
         int rowsUpdated = 0;
         checkCallerAppId();
         // TODO: implement update if necessary
-
-        // getContentResolver provides access to the content model
-        // notifyChange notifies all observers that a row was updated
-        getContext().getContentResolver().notifyChange(uri, null);
         return rowsUpdated;
     }
 

--- a/bundle-core/src/main/java/net/discdd/client/applicationdatamanager/ApplicationDataManager.java
+++ b/bundle-core/src/main/java/net/discdd/client/applicationdatamanager/ApplicationDataManager.java
@@ -88,20 +88,23 @@ public class ApplicationDataManager {
 
     public void storeReceivedADUs(String clientId, String bundleId, List<ADU> adus) {
         logger.log(INFO, "[ADM] Storing ADUs in the Data Store, Size:" + adus.size());
-
         for (final ADU adu : adus) {
-
             try {
-                receiveADUsStorage.addADU(null,
+                var aduFile = receiveADUsStorage.addADU(null,
                                           adu.getAppId(),
                                           Files.readAllBytes(adu.getSource().toPath()),
                                           adu.getADUId());
-                aduConsumer.accept(adu);
+                // if aduFile == null, the ADU was not added
+                if (aduFile != null) {
+                    aduConsumer.accept(adu);
+                }
                 logger.log(FINE, "[ADM] Updated Largest ADU id: " + adu.getADUId() + "," + adu.getSource());
             } catch (IOException e) {
                 logger.log(WARNING, "Could not persist adu: " + adu.getADUId(), e);
             }
         }
+        // this indicates that the batch of ADUs has been finished
+        aduConsumer.accept(null);
     }
 
     public List<ADU> fetchADUsToSend(long initialSize, String clientId) throws IOException {

--- a/bundle-core/src/main/java/net/discdd/client/bundlesecurity/ClientSecurity.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundlesecurity/ClientSecurity.java
@@ -243,10 +243,13 @@ public class ClientSecurity {
 
         String payloadName = SecurityUtils.PAYLOAD_FILENAME;
 
-        InputStream encryptedDataInputStream = Files.newInputStream(payloadPath.resolve(payloadName));
-        OutputStream encryptedDataOutputStream = Files.newOutputStream(decryptedFile);
-        cipherSession.decrypt(encryptedDataInputStream, encryptedDataOutputStream);
-        updateSessionRecord();
+        try (
+                InputStream encryptedDataInputStream = Files.newInputStream(payloadPath.resolve(payloadName));
+                OutputStream encryptedDataOutputStream = Files.newOutputStream(decryptedFile)
+        ){
+            cipherSession.decrypt(encryptedDataInputStream, encryptedDataOutputStream);
+            updateSessionRecord();
+        }
 
         logger.log(FINER, "Decrypted Size = %d\n", Files.size(decryptedPath));
     }

--- a/bundle-core/src/main/java/net/discdd/utils/BundleUtils.java
+++ b/bundle-core/src/main/java/net/discdd/utils/BundleUtils.java
@@ -315,25 +315,25 @@ public class BundleUtils {
                                                   String crashReport,
                                                   OutputStream outputStream) throws IOException,
             NoSuchAlgorithmException {
-        DDDJarFileCreator innerJar = new DDDJarFileCreator(outputStream);
-        if (ackedEncryptedBundleId == null) ackedEncryptedBundleId = "HB";
-        logger.log(INFO, "[BU/createBundlePayload] " + adus.size());
-        // add the records to the inner jar
-        innerJar.createEntry("acknowledgement.txt", ackedEncryptedBundleId.getBytes());
-        innerJar.createEntry("routing.metadata", routingData == null ? "{}".getBytes() : routingData);
-        if (crashReport != null) {
-            innerJar.createEntry("crash_report.txt", crashReport.getBytes());
-        }
+        try (DDDJarFileCreator innerJar = new DDDJarFileCreator(outputStream)) {
+            if (ackedEncryptedBundleId == null) ackedEncryptedBundleId = "HB";
+            logger.log(INFO, "[BU/createBundlePayload] " + adus.size());
+            // add the records to the inner jar
+            innerJar.createEntry("acknowledgement.txt", ackedEncryptedBundleId.getBytes());
+            innerJar.createEntry("routing.metadata", routingData == null ? "{}".getBytes() : routingData);
+            if (crashReport != null) {
+                innerJar.createEntry("crash_report.txt", crashReport.getBytes());
+            }
 
-        for (var adu : adus) {
-            try (var os = innerJar.createEntry(Paths.get(Constants.BUNDLE_ADU_DIRECTORY_NAME,
-                                                         adu.getAppId(),
-                                                         Long.toString(adu.getADUId())));
-                 var aos = Files.newInputStream(adu.getSource().toPath(), StandardOpenOption.READ)) {
-                aos.transferTo(os);
+            for (var adu : adus) {
+                try (var os = innerJar.createEntry(Paths.get(Constants.BUNDLE_ADU_DIRECTORY_NAME,
+                                                             adu.getAppId(),
+                                                             Long.toString(adu.getADUId())));
+                     var aos = Files.newInputStream(adu.getSource().toPath(), StandardOpenOption.READ)) {
+                    aos.transferTo(os);
+                }
             }
         }
-        innerJar.close();
     }
 
     public static void encryptPayloadAndCreateBundle(Encrypter payloadEncryptor,

--- a/bundle-core/src/main/java/net/discdd/utils/DDDJarFileCreator.java
+++ b/bundle-core/src/main/java/net/discdd/utils/DDDJarFileCreator.java
@@ -14,7 +14,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
-public class DDDJarFileCreator {
+public class DDDJarFileCreator implements AutoCloseable {
     private static final String SHA256_ATTRIBUTE_NAME = "SHA-256-Digest";
     final private JarOutputStream jarOutputStream;
     final private Manifest manifest = new Manifest();

--- a/client-adapter/build.gradle
+++ b/client-adapter/build.gradle
@@ -35,17 +35,24 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }
 
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    archiveClassifier.set('sources')
+}
+
 publishing {
     publications {
         release(MavenPublication) {
             groupId = 'net.discdd'
             artifactId = 'client-adapter'
-            version = '0.0.1-SNAPSHOT'
+            version = '0.2.0-SNAPSHOT'
             artifact("$buildDir/outputs/aar/${project.name}-release.aar")
+            artifact(sourcesJar)
         }
     }
 
     repositories {
+        mavenLocal()
         maven {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/SJSU-CS-systems-group/DDD")

--- a/client-adapter/src/main/AndroidManifest.xml
+++ b/client-adapter/src/main/AndroidManifest.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission
-            android:name="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_READ"
-            android:protectionLevel="normal" />
-    <uses-permission
-            android:name="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_WRITE"
-            android:protectionLevel="normal" />
-
     <queries>
         <provider android:authorities="net.discdd.provider.datastoreprovider" />
     </queries>
-
 </manifest>


### PR DESCRIPTION
* cleans up DDDClient
  - explicitly expose reg/unreg methods instead of trying to hook into lifecycle
  - only notify when a new ADU comes in