### PR TITLE
Transport adopts client usb logic

### DIFF
--- a/BundleClient/app/build.gradle
+++ b/BundleClient/app/build.gradle
@@ -17,6 +17,7 @@ if (osName.contains("mac") && osArch.equals("aarch64")) {
 android {
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     composeOptions {

--- a/BundleClient/app/src/androidTest/java/net/discdd/bundleclient/MessageProviderTest.java
+++ b/BundleClient/app/src/androidTest/java/net/discdd/bundleclient/MessageProviderTest.java
@@ -46,8 +46,7 @@ public class MessageProviderTest {
     public void setUp() throws IOException {
         MessageProvider messageProvider = new MessageProvider();
         messageProvider.attachInfo(ApplicationProvider.getApplicationContext(), null);
-        adapter = new DDDClientAdapter(ApplicationProvider.getApplicationContext(),
-                                       NULL_LIFECYCLE, null);
+        adapter = new DDDClientAdapter(ApplicationProvider.getApplicationContext(), null);
         // access the private sendADUsStorage and receiveADUsStorage fields in messageProvider
         String appId = ApplicationProvider.getApplicationContext().getPackageName();
         sendADUStorePath = ApplicationProvider.getApplicationContext().getDataDir().toPath().resolve("send").resolve(appId);

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientActivity.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientActivity.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
 import android.os.Bundle
+import android.os.StrictMode
+import android.os.StrictMode.VmPolicy
 import android.os.storage.StorageManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -31,6 +33,14 @@ class BundleClientActivity: ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        if (BuildConfig.DEBUG) {
+            StrictMode.setVmPolicy(
+                VmPolicy.Builder()
+                    .detectLeakedClosableObjects()
+                    .penaltyLog()
+                    .build()
+            )
+        }
         LogFragment.registerLoggerHandler()
 
         var usbViewModel: ClientUsbViewModel

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientActivity.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/BundleClientActivity.kt
@@ -28,13 +28,12 @@ class BundleClientActivity: ComponentActivity() {
         getSharedPreferences(BundleClientWifiDirectService.NET_DISCDD_BUNDLECLIENT_SETTINGS, MODE_PRIVATE)
     }
 
-    private lateinit var usbViewModel: ClientUsbViewModel
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         LogFragment.registerLoggerHandler()
 
+        var usbViewModel: ClientUsbViewModel
         usbViewModel = ViewModelProvider(this).get(ClientUsbViewModel::class.java)
         val openDocumentTreeLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK) {

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/BundleManagerScreen.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/screens/BundleManagerScreen.kt
@@ -38,30 +38,18 @@ fun ManagerScreen(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            for (app in managerState.appData) {
             Text(
-                text = "k9:",
+                text = app.name,
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold
             )
-            Row(
-                modifier = Modifier
-                    .padding(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
                 Text(
-                    text = stringResource(R.string.sent),
+                    text = "    out: delivered ${app.ackedOut} pending ${app.lastOut - app.ackedOut}",
                     fontSize = 20.sp
                 )
                 Text(
-                    text = managerState.numberBundlesSent,
-                    fontSize = 20.sp
-                )
-                Text(
-                    text = " " + stringResource(R.string.received) + ":",
-                    fontSize = 20.sp
-                )
-                Text(
-                    text = managerState.numberBundlesReceived,
+                    text = "    in: processed ${app.ackedIn} pending ${app.lastIn - app.ackedIn}",
                     fontSize = 20.sp
                 )
             }

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/BundleManagerViewModel.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/BundleManagerViewModel.kt
@@ -37,24 +37,24 @@ class BundleManagerViewModel(
     fun getADUcount(ADUPath: Path?): String {
         ADUPath ?: "0"
         try {
-            val stream = Files.newDirectoryStream(ADUPath)
-            for (path in stream) {
-                if (path.fileName.toString().equals("net.discdd.k9")) {
-                    // check for "metadata.json" and exclude it
-                    if (path.toFile().isDirectory()) {
-                        // Get the list of files and exclude "metadata.json"
-                        val filteredFiles =
-                            path.toFile().listFiles {dir, name -> name != "metadata.json" }
-                                ?.map { it.name }?.toTypedArray() ?: emptyArray()
-                        if (filteredFiles.isNullOrEmpty())
-                            return "0"
-                        return filteredFiles.size.toString()
+            Files.newDirectoryStream(ADUPath).use { stream ->
+                for (path in stream) {
+                    if (path.fileName.toString().equals("net.discdd.k9")) {
+                        // check for "metadata.json" and exclude it
+                        if (path.toFile().isDirectory()) {
+                            // Get the list of files and exclude "metadata.json"
+                            val filteredFiles =
+                                path.toFile().listFiles { dir, name -> name != "metadata.json" }
+                                    ?.map { it.name }?.toTypedArray() ?: emptyArray()
+                            if (filteredFiles.isNullOrEmpty())
+                                return "0"
+                            return filteredFiles.size.toString()
+                        }
+                        return path.toFile().list()?.size?.toString() ?: "0"
                     }
-                    return path.toFile().list()?.size?.toString() ?: "0"
                 }
             }
-        }
-        catch (e : Exception) {
+        } catch (e : Exception) {
             when (e) {
                 is IOException, is DirectoryIteratorException -> {
                     System.err.println("Error reading the directory: ${e.message}");

--- a/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/BundleManagerViewModel.kt
+++ b/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/BundleManagerViewModel.kt
@@ -7,19 +7,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import net.discdd.bundleclient.R
 import net.discdd.bundleclient.WifiServiceManager
+import net.discdd.client.bundletransmission.BundleTransmission
+import java.util.stream.Collectors
 
-import net.discdd.client.bundletransmission.BundleTransmission;
-
-import java.io.IOException;
-import java.nio.file.DirectoryIteratorException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+data class BundleManagerApp (
+    val name: String,
+    val lastOut: Long,
+    val ackedOut: Long,
+    val lastIn: Long,
+    val ackedIn: Long,
+)
 
 data class BundleManagerState(
-    val numberBundlesSent: String = "0",
-    val numberBundlesReceived: String = "0",
+    val appData: List<BundleManagerApp> = emptyList(),
 )
 
 class BundleManagerViewModel(
@@ -30,55 +31,34 @@ class BundleManagerViewModel(
     val state = _state.asStateFlow()
 
     init {
-        bundleTransmission = WifiServiceManager.getService()?.getBundleTransmission()
+        bundleTransmission = WifiServiceManager.getService()?.bundleTransmission
         refresh()
-    }
-
-    fun getADUcount(ADUPath: Path?): String {
-        ADUPath ?: "0"
-        try {
-            Files.newDirectoryStream(ADUPath).use { stream ->
-                for (path in stream) {
-                    if (path.fileName.toString().equals("net.discdd.k9")) {
-                        // check for "metadata.json" and exclude it
-                        if (path.toFile().isDirectory()) {
-                            // Get the list of files and exclude "metadata.json"
-                            val filteredFiles =
-                                path.toFile().listFiles { dir, name -> name != "metadata.json" }
-                                    ?.map { it.name }?.toTypedArray() ?: emptyArray()
-                            if (filteredFiles.isNullOrEmpty())
-                                return "0"
-                            return filteredFiles.size.toString()
-                        }
-                        return path.toFile().list()?.size?.toString() ?: "0"
-                    }
-                }
-            }
-        } catch (e : Exception) {
-            when (e) {
-                is IOException, is DirectoryIteratorException -> {
-                    System.err.println("Error reading the directory: ${e.message}");
-                    return "0";
-                }
-            }
-        }
-        return "0"
     }
 
     fun refresh() {
         viewModelScope.launch {
-            var path: Path? = bundleTransmission?.getClientPaths()?.sendADUsPath
-            try {
-                _state.update {
-                    it.copy(numberBundlesSent = getADUcount(path),
-                        numberBundlesReceived = getADUcount(path))
-                }
-            } catch (e : Exception) {
-                System.err.println("Error updating ADU count: ${e.message}");
-                _state.update {
-                    it.copy(numberBundlesSent = "Error",
-                        numberBundlesReceived = "Error")
-                }
+            val sendADUs = bundleTransmission?.applicationDataManager?.sendADUsStorage
+            val recvADUs = bundleTransmission?.applicationDataManager?.receiveADUsStorage
+
+            if (sendADUs == null || recvADUs == null) {
+                return@launch
+            }
+            val list = sendADUs.getAllClientApps(true).map {
+                val sendMeta = sendADUs.getMetadata(null, it.appId)
+                val recvMeta = recvADUs.getMetadata(null, it.appId)
+
+                BundleManagerApp(
+                    name = it.appId.substringAfterLast('.'),
+                    lastOut = sendMeta.lastAduAdded,
+                    ackedOut = sendMeta.lastAduDeleted,
+                    lastIn = recvMeta.lastAduAdded,
+                    ackedIn = recvMeta.lastAduDeleted,
+                )
+            }.collect(Collectors.toList())
+            _state.update {
+                it.copy(
+                    appData = list,
+                )
             }
         }
     }

--- a/BundleClient/app/src/main/java/net/discdd/datastore/providers/MessageProvider.java
+++ b/BundleClient/app/src/main/java/net/discdd/datastore/providers/MessageProvider.java
@@ -29,7 +29,7 @@ public class MessageProvider extends ContentProvider {
 
     private static final Logger logger = Logger.getLogger(MessageProvider.class.getName());
     public static final String PROVIDER_NAME = "net.discdd.provider.datastoreprovider";
-    public static final String URL = "content://" + PROVIDER_NAME + "/messages";
+    public static final Uri URL = Uri.parse("content://" +  PROVIDER_NAME + "/messages");
     public static final int MAX_ADU_SIZE = 512*1024;
 
     private StoreADUs sendADUsStorage;
@@ -164,7 +164,6 @@ public class MessageProvider extends ContentProvider {
             if ("deleteAllADUsUpto".equals(selection) && selectionArgs != null && selectionArgs.length == 1) {
                 long lastProcessedADUId = Long.parseLong(selectionArgs[0]);
                 receiveADUsStorage.deleteAllFilesUpTo(null, appName, lastProcessedADUId);
-                getContext().getContentResolver().notifyChange(uri, null);
                 return 1;
             }
             return 0;
@@ -181,10 +180,6 @@ public class MessageProvider extends ContentProvider {
         int rowsUpdated = 0;
         checkCallerAppId();
         // TODO: implement update if necessary
-
-        // getContentResolver provides access to the content model
-        // notifyChange notifies all observers that a row was updated
-        getContext().getContentResolver().notifyChange(uri, null);
         return rowsUpdated;
     }
 

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
@@ -7,6 +7,7 @@ import android.os.storage.StorageManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.lifecycle.ViewModelProvider
 import net.discdd.UsbConnectionManager
 import net.discdd.bundletransport.screens.TransportHomeScreen
 import net.discdd.bundletransport.viewmodels.TransportUsbViewModel

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
@@ -26,6 +26,8 @@ class BundleTransportActivity : ComponentActivity() {
         TransportPaths(applicationContext.filesDir.toPath())
     }
 
+    private lateinit var usbViewModel: TransportUsbViewModel
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -46,7 +48,7 @@ class BundleTransportActivity : ComponentActivity() {
         usbViewModel.requestDirectoryAccess.observe(this) {
             val storageManager = getSystemService(Context.STORAGE_SERVICE) as StorageManager
             val volumes = storageManager.storageVolumes
-            val usbVolume = volumes.find { it.isRemovable && it.state == "mounted" }
+            val usbVolume = volumes.find { it.isRemovable && it.state == "mounted"}
             usbVolume?.createOpenDocumentTreeIntent()?.apply {
                 openDocumentTreeLauncher.launch(this)
             }

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
@@ -26,16 +26,13 @@ class BundleTransportActivity : ComponentActivity() {
         TransportPaths(applicationContext.filesDir.toPath())
     }
 
-    private lateinit var usbViewModel: TransportUsbViewModel
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         LogFragment.registerLoggerHandler()
 
-        //var usbViewModel: TransportUsbViewModel
-        //usbViewModel = ViewModelProvider(this).get(TransportUsbViewModel::class.java)
-        val usbViewModel = TransportUsbViewModel(application, this)
+        var usbViewModel: TransportUsbViewModel
+        usbViewModel = ViewModelProvider(this).get(TransportUsbViewModel::class.java)
         val openDocumentTreeLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK) {
                 usbViewModel.openedURI(applicationContext, result.data?.data)

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
@@ -7,7 +7,6 @@ import android.os.storage.StorageManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.lifecycle.ViewModelProvider
 import net.discdd.UsbConnectionManager
 import net.discdd.bundletransport.screens.TransportHomeScreen
 import net.discdd.bundletransport.viewmodels.TransportUsbViewModel
@@ -31,8 +30,9 @@ class BundleTransportActivity : ComponentActivity() {
 
         LogFragment.registerLoggerHandler()
 
-        var usbViewModel: TransportUsbViewModel
-        usbViewModel = ViewModelProvider(this).get(TransportUsbViewModel::class.java)
+        //var usbViewModel: TransportUsbViewModel
+        //usbViewModel = ViewModelProvider(this).get(TransportUsbViewModel::class.java)
+        val usbViewModel = TransportUsbViewModel(application, this)
         val openDocumentTreeLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK) {
                 usbViewModel.openedURI(applicationContext, result.data?.data)

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
@@ -46,7 +46,7 @@ class BundleTransportActivity : ComponentActivity() {
         usbViewModel.requestDirectoryAccess.observe(this) {
             val storageManager = getSystemService(Context.STORAGE_SERVICE) as StorageManager
             val volumes = storageManager.storageVolumes
-            val usbVolume = volumes.find { it.isRemovable && it.state == "mounted"}
+            val usbVolume = volumes.find { it.isRemovable && it.state == "mounted" }
             usbVolume?.createOpenDocumentTreeIntent()?.apply {
                 openDocumentTreeLauncher.launch(this)
             }

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportActivity.kt
@@ -26,13 +26,12 @@ class BundleTransportActivity : ComponentActivity() {
         TransportPaths(applicationContext.filesDir.toPath())
     }
 
-    private lateinit var usbViewModel: TransportUsbViewModel
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         LogFragment.registerLoggerHandler()
 
+        var usbViewModel: TransportUsbViewModel
         usbViewModel = ViewModelProvider(this).get(TransportUsbViewModel::class.java)
         val openDocumentTreeLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK) {

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/UsbFileManager.java
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/UsbFileManager.java
@@ -3,6 +3,7 @@ package net.discdd.bundletransport;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.WARNING;
 
+import android.content.Context;
 import android.os.storage.StorageManager;
 import android.os.storage.StorageVolume;
 
@@ -27,12 +28,16 @@ public class UsbFileManager {
     private static final String USB_DIR_NAME = "DDD_transport";
     private static final String RELATIVE_CLIENT_PATH = "client";
     private static final String RELATIVE_SERVER_PATH = "server";
+    private static final String MAIL_APK_URL = "https://github.com/SJSU-CS-systems-group/DDD-thunderbird-android/releases/latest/download/ddd-mail.apk";
+    private static final String CLIENT_APK_URL = "https://github.com/SJSU-CS-systems-group/DDD/releases/latest/download/DDDClient.apk";
     private StorageManager storageManager;
     private TransportPaths transportPaths;
+    private Context context;
 
-    public UsbFileManager(StorageManager storageManager, TransportPaths transportPaths) {
+    public UsbFileManager(StorageManager storageManager, TransportPaths transportPaths, Context context) {
         this.storageManager = storageManager;
         this.transportPaths = transportPaths;
+        this.context = context;
     }
 
     /**
@@ -71,6 +76,7 @@ public class UsbFileManager {
                         throw new RuntimeException("Bad call to populate USB or Android device", e);
                     } finally {
                         reduceUsbFiles(usbTransportToClientDir, usbTransportToServerDir);
+                        addApkFiles(usbTransportToClientDir);
                         return result;
                     }
                 }
@@ -170,5 +176,18 @@ public class UsbFileManager {
               "Successfully deleted excess server files from USB" :
               "No excess server files to delete from USB";
         logger.log(INFO, res);
+    }
+
+    private void addApkFiles(File apkDest) {
+        logger.log(INFO, "USBFILEMANAGER: THIS IS OUR APK DEST DIR " + apkDest);
+        String apkFileName = MAIL_APK_URL + '/';
+        File apkRoot = context.getExternalFilesDir(null);
+        File file = new File(apkRoot, apkFileName);
+        logger.log(INFO, "USBFILEMANAGER: THIS IS OUR APK FILE " + file);
+        try {
+            Files.copy(apkDest.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportHomeScreen.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportHomeScreen.kt
@@ -1,6 +1,7 @@
 package net.discdd.bundletransport.screens
 
 import android.Manifest
+import android.app.Application
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -123,15 +124,18 @@ fun TransportHomeScreen(
     )
 
     val usbTab = TabItem(
-            title = stringResource(R.string.usb),
-            screen = {
-                val usbViewModel: TransportUsbViewModel = viewModel()
-                UsbScreen(usbViewModel) { viewModel ->
-                    TransportUsbComponent(viewModel) {
-                        viewModel.populate()
-                    }
+        title = stringResource(R.string.usb),
+        screen = {
+            val context = LocalContext.current
+            val usbViewModel = remember {
+                TransportUsbViewModel(context.applicationContext as Application, context)
+            }
+            UsbScreen(usbViewModel) { viewModel ->
+                TransportUsbComponent(viewModel) {
+                    viewModel.populate()
                 }
             }
+        }
     )
 
     var tabItems by remember {

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportUsbComponent.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportUsbComponent.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,6 +26,7 @@ fun TransportUsbComponent(
         usbViewModel: TransportUsbViewModel,
         onTransferClick: () -> Unit,
 ) {
+    val context = LocalContext.current
     val usbState by usbViewModel.state.collectAsState()
     val isUsbConnected by UsbConnectionManager.usbConnected.collectAsState()
 
@@ -91,6 +93,7 @@ fun TransportUsbComponent(
 @Preview(showBackground = true)
 @Composable
 fun TransportUsbComponentPreview() {
-    val viewModel = TransportUsbViewModel(Application())
+    val context = LocalContext.current
+    val viewModel = TransportUsbViewModel(Application(), context)
     TransportUsbComponent(viewModel) {}
 }

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/WifiDirectScreen.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/WifiDirectScreen.kt
@@ -149,11 +149,12 @@ fun WifiDirectScreen(
                 }
 
                 Text(text = "Wifi Status: ${state.wifiStatus}")
-                Text(text = "Device Name: ${state.deviceName}")
 
                 // only show the name change button if we don't have a valid device name
                 // (transports must have device names starting with ddd_)
-                if (!nameValid) {
+                if (nameValid) {
+                    Text(text = "Device Name: ${state.deviceName}")
+                } else {
                     Text(text = stringResource(
                             R.string.phone_name_must_start_with_ddd_found,
                             state.deviceName

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/TransportUsbViewModel.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/TransportUsbViewModel.kt
@@ -1,6 +1,7 @@
 package net.discdd.bundletransport.viewmodels
 
 import android.app.Application
+import android.content.Context
 import android.graphics.Color
 import net.discdd.bundletransport.UsbFileManager
 import net.discdd.pathutils.TransportPaths
@@ -8,11 +9,12 @@ import net.discdd.viewmodels.UsbViewModel
 
 class TransportUsbViewModel(
         application: Application,
+        private val context: Context
 ) : UsbViewModel(application) {
     private val transportPaths by lazy {
         TransportPaths(application.filesDir.toPath())
     }
-    private var usbFileManager: UsbFileManager = UsbFileManager(storageManager, transportPaths)
+    private var usbFileManager: UsbFileManager = UsbFileManager(storageManager, transportPaths, context)
 
     fun populate() {
         try {

--- a/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/WifiDirectViewModel.kt
+++ b/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/WifiDirectViewModel.kt
@@ -80,7 +80,7 @@ class WifiDirectViewModel(
 
             var serviceName = btService!!.deviceName
             _state.update {
-                it.copy(deviceName = if (serviceName != null) serviceName else "Unknown")
+                it.copy(deviceName = if (!serviceName.isNullOrBlank()) serviceName else "Unknown")
             }
 
             var status = btService!!.status

--- a/android-core/src/main/java/net/discdd/wifidirect/WifiDirectManager.java
+++ b/android-core/src/main/java/net/discdd/wifidirect/WifiDirectManager.java
@@ -70,7 +70,9 @@ public class WifiDirectManager {
         intentFilter.addAction(WIFI_P2P_DISCOVERY_CHANGED_ACTION);
     }
 
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
+
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
+                                  Manifest.permission.NEARBY_WIFI_DEVICES })
     public void initialize() {
         this.manager = (WifiP2pManager) this.context.getSystemService(Context.WIFI_P2P_SERVICE);
         if (manager == null) {
@@ -92,7 +94,8 @@ public class WifiDirectManager {
     }
 
     // package protected so that the broadcast receiver can call it
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
+                                  Manifest.permission.NEARBY_WIFI_DEVICES })
     void processDeviceInfo(WifiP2pDevice wifiP2pDevice) {
         if (wifiP2pDevice != null) {
             var infoChanged = false;
@@ -149,7 +152,9 @@ public class WifiDirectManager {
         return completableActionListener;
     }
 
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
+
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
+                                  Manifest.permission.NEARBY_WIFI_DEVICES })
     public CompletableFuture<WifiP2pGroup> createGroup() {
         var completableFuture = new CompletableFuture<WifiP2pGroup>();
         this.manager.createGroup(this.channel, new WifiP2pManager.ActionListener() {
@@ -207,7 +212,8 @@ public class WifiDirectManager {
         return cFuture;
     }
 
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
+                                  Manifest.permission.NEARBY_WIFI_DEVICES })
     public CompletableFuture<WifiP2pGroup> connect(WifiP2pDevice device) {
         CompletableFuture<WifiP2pGroup> completableFuture = new CompletableFuture<>();
         var config = new WifiP2pConfig();
@@ -272,7 +278,8 @@ public class WifiDirectManager {
         getContext().registerReceiver(receiver, intentFilter, Context.RECEIVER_NOT_EXPORTED);
     }
 
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
+                                  Manifest.permission.NEARBY_WIFI_DEVICES })
     public CompletableFuture<WifiP2pDevice> requestDeviceInfo() {
         var completableFuture = new CompletableFuture<WifiP2pDevice>();
         manager.requestDeviceInfo(channel, di -> {

--- a/android-core/src/main/java/net/discdd/wifidirect/WifiDirectManager.java
+++ b/android-core/src/main/java/net/discdd/wifidirect/WifiDirectManager.java
@@ -70,9 +70,7 @@ public class WifiDirectManager {
         intentFilter.addAction(WIFI_P2P_DISCOVERY_CHANGED_ACTION);
     }
 
-
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
-                                  Manifest.permission.NEARBY_WIFI_DEVICES })
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
     public void initialize() {
         this.manager = (WifiP2pManager) this.context.getSystemService(Context.WIFI_P2P_SERVICE);
         if (manager == null) {
@@ -94,8 +92,7 @@ public class WifiDirectManager {
     }
 
     // package protected so that the broadcast receiver can call it
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
-                                  Manifest.permission.NEARBY_WIFI_DEVICES })
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
     void processDeviceInfo(WifiP2pDevice wifiP2pDevice) {
         if (wifiP2pDevice != null) {
             var infoChanged = false;
@@ -152,9 +149,7 @@ public class WifiDirectManager {
         return completableActionListener;
     }
 
-
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
-                                  Manifest.permission.NEARBY_WIFI_DEVICES })
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
     public CompletableFuture<WifiP2pGroup> createGroup() {
         var completableFuture = new CompletableFuture<WifiP2pGroup>();
         this.manager.createGroup(this.channel, new WifiP2pManager.ActionListener() {
@@ -212,8 +207,7 @@ public class WifiDirectManager {
         return cFuture;
     }
 
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
-                                  Manifest.permission.NEARBY_WIFI_DEVICES })
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
     public CompletableFuture<WifiP2pGroup> connect(WifiP2pDevice device) {
         CompletableFuture<WifiP2pGroup> completableFuture = new CompletableFuture<>();
         var config = new WifiP2pConfig();
@@ -278,8 +272,7 @@ public class WifiDirectManager {
         getContext().registerReceiver(receiver, intentFilter, Context.RECEIVER_NOT_EXPORTED);
     }
 
-    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION,
-                                  Manifest.permission.NEARBY_WIFI_DEVICES })
+    @RequiresPermission(allOf = { Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.NEARBY_WIFI_DEVICES })
     public CompletableFuture<WifiP2pDevice> requestDeviceInfo() {
         var completableFuture = new CompletableFuture<WifiP2pDevice>();
         manager.requestDeviceInfo(channel, di -> {

--- a/apps/k9/server/pom.xml
+++ b/apps/k9/server/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -18,9 +18,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>javax.mail</groupId>
-            <artifactId>javax.mail-api</artifactId>
-            <version>1.6.2</version>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.sun.mail</groupId>
@@ -55,7 +55,16 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.simplejavamail</groupId>
+            <artifactId>simple-java-mail</artifactId>
+            <version>8.12.6</version>
+        </dependency>
+        <dependency>
+            <groupId>net.mailific</groupId>
+            <artifactId>mailific-serverlib</artifactId>
+            <version>1.0.4</version>
+        </dependency>
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
@@ -104,5 +113,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/apps/k9/server/pom.xml
+++ b/apps/k9/server/pom.xml
@@ -61,9 +61,24 @@
             <version>8.12.6</version>
         </dependency>
         <dependency>
+            <groupId>org.simplejavamail</groupId>
+            <artifactId>dkim-module</artifactId>
+            <version>8.12.6</version>
+        </dependency>
+        <dependency>
             <groupId>net.mailific</groupId>
             <artifactId>mailific-serverlib</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.james.jspf</groupId>
+            <artifactId>apache-jspf-resolver</artifactId>
+            <version>1.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>dnsjava</groupId>
+            <artifactId>dnsjava</artifactId>
+            <version>3.6.3</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/K9Config.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/K9Config.java
@@ -1,0 +1,16 @@
+package net.discdd.app.k9;
+
+import net.discdd.utils.StoreADUs;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.file.Path;
+
+@Configuration
+public class K9Config {
+    @Bean
+    public StoreADUs sendStoreADUs(@Value("${adapter-server.rootdir}") Path rootDir) {
+        return new StoreADUs(rootDir.resolve("send"), true);
+    }
+}

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/K9DDDAdapter.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/K9DDDAdapter.java
@@ -52,7 +52,7 @@ public class K9DDDAdapter extends ServiceAdapterServiceGrpc.ServiceAdapterServic
     // yahoo and gmail are 25M and MS is 20M
     public static final int MAX_DATA_SIZE = 1024 * 1024 * 20;
     // we will allow extermin incoming mails that are 25% more than MAX_DATA_SIZE
-    public static final int MAX_RECV_DATA_SIZE = (int)(MAX_DATA_SIZE * 1.25);
+    public static final int MAX_RECV_DATA_SIZE = (int) (MAX_DATA_SIZE * 1.25);
     public static final String APP_ID = "net.discdd.k9";
     private final Random rand = new Random();
     private final StoreADUs sendADUsStorage;

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/K9DDDAdapter.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/K9DDDAdapter.java
@@ -28,6 +28,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/repository/entity/K9ClientIdToEmailMapping.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/repository/entity/K9ClientIdToEmailMapping.java
@@ -16,6 +16,7 @@ public class K9ClientIdToEmailMapping {
     public String clientId;
     @Column(columnDefinition = "text", nullable = false)
     public String password;
+
     public String toString() {
         return String.format("%s -> %s", email, clientId);
     }

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/repository/entity/K9ClientIdToEmailMapping.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/repository/entity/K9ClientIdToEmailMapping.java
@@ -16,4 +16,7 @@ public class K9ClientIdToEmailMapping {
     public String clientId;
     @Column(columnDefinition = "text", nullable = false)
     public String password;
+    public String toString() {
+        return String.format("%s -> %s", email, clientId);
+    }
 }

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/service/EmailService.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/service/EmailService.java
@@ -1,0 +1,58 @@
+package net.discdd.app.k9.service;
+
+import jakarta.mail.internet.MimeMessage;
+import org.simplejavamail.api.mailer.config.TransportStrategy;
+import org.simplejavamail.email.EmailBuilder;
+import org.simplejavamail.mailer.MailerBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Service;
+
+import java.util.logging.Logger;
+
+import static java.lang.String.format;
+
+@Service
+public class EmailService implements ApplicationRunner {
+    public static final Logger logger = Logger.getLogger(EmailService.class.getName());
+    public final String relayHost;
+    public final int relayPort;
+    public final String localDomain;
+
+    EmailService(@Value("${smtp.relay.host}") String relayHost,
+                 @Value("${smtp.relay.port}") int relayPort,
+                 @Value("${smtp.localDomain}") String localDomain) {
+        this.relayHost = relayHost;
+        this.relayPort = relayPort;
+        this.localDomain = localDomain;
+        logger.info(format("EmailService %s initialized relayHost: %s:%s", localDomain, relayHost, relayPort));
+    }
+
+    public void sendExternalEmail(MimeMessage mimeMessage) throws Exception {
+        var emailBuilder = EmailBuilder.copying(mimeMessage);
+        var filteredRecipients = emailBuilder.getRecipients()
+                .stream()
+                .filter(recipient -> !recipient.getAddress().split("@")[1].equals(localDomain))
+                .toList();
+        emailBuilder.clearRecipients();
+        emailBuilder.withRecipients(filteredRecipients);
+        var email = emailBuilder.buildEmail();
+
+        try (var mailer = MailerBuilder.withSMTPServer(relayHost, relayPort)
+                .withTransportStrategy(TransportStrategy.SMTP)
+                .withProperty("mail.smtp.localhost", localDomain)
+                .withProperty("mail.smtp.starttls.enable", "false")
+                .withProperty("mail.smtp.starttls.required", "false")
+                .withProperty("mail.smtp.ssl.enable", "false")
+                .withDebugLogging(true)
+                .buildMailer()) {
+            mailer.sendMail(email).get();
+        }
+    }
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+
+    }
+}

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/service/EmailService.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/service/EmailService.java
@@ -1,17 +1,48 @@
 package net.discdd.app.k9.service;
 
+import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import net.discdd.app.k9.K9DDDAdapter;
+import net.discdd.app.k9.repository.K9ClientIdToEmailMappingRepository;
+import net.discdd.utils.StoreADUs;
+import net.mailific.main.Main;
+import net.mailific.server.ServerConfig;
+import net.mailific.server.commands.BaseHandler;
+import net.mailific.server.commands.ParsedCommandLine;
+import net.mailific.server.netty.NettySmtpServer;
+import net.mailific.server.reference.BaseMailObject;
+import net.mailific.server.session.Reply;
+import net.mailific.server.session.SessionState;
+import net.mailific.server.session.SmtpSession;
+import net.mailific.server.session.StandardStates;
+import net.mailific.server.session.Transition;
+import org.apache.james.jspf.impl.DefaultSPF;
+import org.simplejavamail.api.email.config.DkimConfig;
 import org.simplejavamail.api.mailer.config.TransportStrategy;
 import org.simplejavamail.email.EmailBuilder;
 import org.simplejavamail.mailer.MailerBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.stereotype.Service;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static java.lang.String.format;
+import static net.discdd.app.k9.K9DDDAdapter.MAX_RECIPIENTS;
+import static net.discdd.app.k9.K9DDDAdapter.MAX_RECV_DATA_SIZE;
 
 @Service
 public class EmailService implements ApplicationRunner {
@@ -19,24 +50,73 @@ public class EmailService implements ApplicationRunner {
     public final String relayHost;
     public final int relayPort;
     public final String localDomain;
+    private final DkimConfig dkim;
+    private final int localPort;
+    private final String tlsCert;
+    private final String tlsPrivate;
+    private final String tlsPrivatePassword;
+    private final ConfigurableApplicationContext context;
+    private final K9ClientIdToEmailMappingRepository clientToEmailRepository;
+    private final StoreADUs storeADUs;
 
     EmailService(@Value("${smtp.relay.host}") String relayHost,
                  @Value("${smtp.relay.port}") int relayPort,
-                 @Value("${smtp.localDomain}") String localDomain) {
+                 @Value("${smtp.localDomain}") String localDomain,
+                 @Value("${smtp.localPort}") int localPort,
+                 @Value("${smtp.dkim.keyFile:#{null}}") String keyFile,
+                 @Value("${smtp.tls.cert:#{null}}") String tlsCert,
+                 @Value("${smtp.tls.private:#{null}}") String tlsPrivate,
+                 @Value("${smtp.tls.privatePassword:#{null}}") String tlsPrivatePassword,
+                 K9ClientIdToEmailMappingRepository clientToEmailRepository,
+                 StoreADUs storeADUs,
+                 ConfigurableApplicationContext context) throws IOException {
+        this.context = context;
         this.relayHost = relayHost;
         this.relayPort = relayPort;
-        this.localDomain = localDomain;
-        logger.info(format("EmailService %s initialized relayHost: %s:%s", localDomain, relayHost, relayPort));
+        this.localDomain = localDomain.toLowerCase();
+        this.localPort = localPort;
+        this.tlsCert = tlsCert;
+        this.tlsPrivate = tlsPrivate;
+        this.tlsPrivatePassword = tlsPrivatePassword;
+        this.clientToEmailRepository = clientToEmailRepository;
+        this.storeADUs = storeADUs;
+        if (keyFile != null) {
+            var privateKey = Base64.getDecoder().decode(unPEM(Files.readString(Path.of(keyFile))));
+            var dkimBuilder =
+                    DkimConfig.builder().excludedHeadersFromDkimDefaultSigningList("From", "Subject") // default is none
+                            .dkimPrivateKeyData(privateKey).dkimSigningDomain(localDomain).dkimSelector("mail");
+            dkim = dkimBuilder.useLengthParam(true) // default is false
+                    .headerCanonicalization(DkimConfig.Canonicalization.SIMPLE) // default is RELAXED
+                    .bodyCanonicalization(DkimConfig.Canonicalization.SIMPLE) // default is RELAXED
+                    .build();
+            logger.info(format("✅ EmailService %s initialized dkim mail selector with keyFile: %s",
+                               localDomain,
+                               keyFile));
+        } else {
+            dkim = null;
+            logger.info("⚠️ Dkim signing is disabled, no keyFile provided");
+        }
+
+        logger.info(format("✅ EmailService %s initialized relayHost: %s:%s", localDomain, relayHost, relayPort));
+    }
+
+    public static String unPEM(String pem) {
+        return pem.replaceAll("--+[^-]+--+", "").replace("\n", "").replace("\r", "");
     }
 
     public void sendExternalEmail(MimeMessage mimeMessage) throws Exception {
         var emailBuilder = EmailBuilder.copying(mimeMessage);
+
+        // make sure we are only sending to the non-local recipients
         var filteredRecipients = emailBuilder.getRecipients()
                 .stream()
                 .filter(recipient -> !recipient.getAddress().split("@")[1].equals(localDomain))
                 .toList();
         emailBuilder.clearRecipients();
         emailBuilder.withRecipients(filteredRecipients);
+        if (dkim != null) {
+            emailBuilder.signWithDomainKey(dkim);
+        }
         var email = emailBuilder.buildEmail();
 
         try (var mailer = MailerBuilder.withSMTPServer(relayHost, relayPort)
@@ -54,5 +134,168 @@ public class EmailService implements ApplicationRunner {
     @Override
     public void run(ApplicationArguments args) throws Exception {
 
+        ServerConfig.Builder builder = Main.defaultServerConfigBuilder(s -> new DDDMailObject());
+        var tlsEnabled = false;
+        if (tlsCert == null) {
+            // No TLS certificate provided, so we assume an SMTP proxy that is using the proxy_protocol
+            var commandHandlers = Main.baseCommandHandlers(localDomain, localDomain, s -> new DDDMailObject());
+            commandHandlers.put("PROXY", new ProxyCommand());
+            builder.withCommandHandlers(commandHandlers.values());
+            logger.info("⚠️ PROXY command installed.!");
+        } else {
+            var tlsCertFile = new File(tlsCert);
+            var tlsPrivateFile = new File(tlsPrivate);
+            if (!tlsCertFile.canRead() || !tlsPrivateFile.canRead()) {
+                logger.severe(format(
+                        "Both the TLS certificate file (%s) and private key file (%s) must exist and be readable",
+                        tlsCert,
+                        tlsPrivate));
+                SpringApplication.exit(context, () -> 2);
+                return;
+            }
+            builder.withTlsCert(tlsCertFile).withTlsCertKey(tlsPrivateFile);
+            if (tlsPrivatePassword != null) {
+                builder.withTlsCertPassword(tlsPrivatePassword);
+            }
+            tlsEnabled = true;
+        }
+        builder.withListenPort(localPort);
+        builder.withListenHost("::");
+        new NettySmtpServer(builder.build()).start();
+
+        if (tlsEnabled) {
+            logger.info(format("✅ Mailific server with TLS started on port %s", localPort));
+        } else {
+            logger.warning(format("⚠️ Mailific server WITHOUT TLS started on port %s", localPort));
+            logger.warning("⚠️ Assuming an SMTP proxy that is doing the SPF check, so skipping check here!");
+        }
     }
+
+    static public class ProxyCommand extends BaseHandler {
+        public static final String SESSION_CLIENTIP_PROPERTY = "proxied-client.ip";
+
+        @Override
+        protected Transition handleValidCommand(SmtpSession session, String commandLine) {
+            var parts = commandLine.split(" ");
+            // line is of the form:
+            // PROXY TCP4 src_ip dst_ip src_port dst_port
+            var clientIp = parts[2];
+            session.setProperty(SESSION_CLIENTIP_PROPERTY, clientIp);
+            return new Transition(Reply.DO_NOT_REPLY, SessionState.NO_STATE_CHANGE);
+        }
+
+        @Override
+        protected boolean validForState(SessionState state) {
+            return state == StandardStates.CONNECTED;
+        }
+
+        @Override
+        public String verb() {
+            return "PROXY";
+        }
+    }
+
+    class DDDMailObject extends BaseMailObject {
+        DefaultSPF spfValidator = new DefaultSPF();
+        List<String> rcptClientIds = new ArrayList<>();
+        ByteArrayOutputStream baos;
+
+        private static String stripEmailAddress(String addr) {
+            if (addr.contains(">")) {
+                int end = addr.indexOf(">");
+                int begin = addr.lastIndexOf("<");
+                return addr.substring(begin + 1, end);
+            }
+            return addr;
+        }
+
+        @Override
+        public Reply mailFrom(ParsedCommandLine mailFrom, SmtpSession session) {
+            var superReply = super.mailFrom(mailFrom, session);
+            if (superReply.success()) {
+                var ehloCommand = session.getEhloCommandLine();
+                if (ehloCommand == null) {
+                    return new Reply(500, "5.5.1 EHLO required before MAIL FROM");
+                }
+                var ehloHost = session.getEhloCommandLine().getPath();
+                var from = stripEmailAddress(mailFrom.getPath());
+
+                // No TLS private key, so we assume an SMTP proxy is going to send us a proxy command
+                var ipAddress = tlsPrivate == null ?
+                                (String) session.getProperty(ProxyCommand.SESSION_CLIENTIP_PROPERTY) :
+                                session.getRemoteAddress().getAddress().getHostAddress();
+
+                var result = spfValidator.checkSPF(ipAddress, from, ehloHost);
+                String status = result.getResult();
+                String explanation = result.getExplanation(); // May be null if no explanation available
+                if (!"pass".equalsIgnoreCase(status)) {
+                    String reason = explanation != null ? explanation : "SPF failed";
+                    return new Reply(550, "5.7.23 SPF check failed: " + reason);
+                }
+                logger.log(Level.INFO, format("Receiving mail from %s", from));
+            }
+            return superReply;
+        }
+
+        @Override
+        public Reply offerRecipient(ParsedCommandLine rcpt) {
+            var addr = stripEmailAddress(rcpt.getPath());
+            var parts = addr.split("@");
+            if (parts.length != 2 || !parts[1].toLowerCase().equals(localDomain)) {
+                return new Reply(550, "5.1.6 Recipient is not in the local domain");
+            }
+            var rec = clientToEmailRepository.findById(addr);
+            logger.log(Level.INFO, format("Mail for %s going to %s", addr, rec));
+            if (rec.isEmpty()) {
+                return new Reply(550, "5.1.1 Recipient does not exist");
+            }
+            rcptClientIds.add(rec.get().clientId);
+            if (rcptClientIds.size() > MAX_RECIPIENTS) {
+                return new Reply(550, "5.1.1 Recipient exceeds maximum number of recipients");
+            }
+            return super.offerRecipient(rcpt);
+        }
+
+        @Override
+        public Reply complete(SmtpSession session) {
+            var data = baos.toByteArray();
+            try {
+                var message = new MimeMessage(null, new ByteArrayInputStream(data));
+                // TODO: we should really really check the SMTP from with the message from!!!
+                String[] dkimHeaders = message.getHeader("DKIM-Signature");
+                if (dkimHeaders != null && dkimHeaders.length > 0) {
+                    logger.info("Found dkim headers, skipping verification");
+                }
+
+            } catch (MessagingException e) {
+                logger.log(Level.INFO, format("Failed to parse message from received data: %s", e.getMessage()), e);
+            }
+            // create those ADUs!
+            try {
+                for (var clientId : rcptClientIds) {
+                    storeADUs.addADU(clientId, K9DDDAdapter.APP_ID, data, -1);
+                }
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, format("Failed to store ADUs for %s", rcptClientIds), e);
+                return new Reply(550, "4.3.1 Failed to store ADUs");
+            }
+            return super.complete(session);
+        }
+
+        @Override
+        public void writeLine(byte[] line, int offset, int length) throws IOException {
+            if (baos.size() + length > MAX_RECV_DATA_SIZE) {
+                throw new IOException(format("Exceeded maximum data size %s", MAX_RECV_DATA_SIZE));
+            }
+            baos.write(line, offset, length);
+            super.writeLine(line, offset, length);
+        }
+
+        @Override
+        public void prepareForData(SmtpSession session) {
+            baos = new ByteArrayOutputStream();
+            super.prepareForData(session);
+        }
+    }
+
 }

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/utils/MailUtils.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/utils/MailUtils.java
@@ -32,6 +32,7 @@ public class MailUtils {
             }
         }
     }
+
     public static List<InternetAddress> getToCCBccAddresses(MimeMessage message) {
         List<InternetAddress> addressList = new ArrayList<>();
         try {

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/utils/MailUtils.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/utils/MailUtils.java
@@ -1,15 +1,13 @@
 package net.discdd.app.k9.utils;
 
-import javax.mail.Address;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-import java.io.ByteArrayInputStream;
+import jakarta.mail.Address;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -25,14 +23,17 @@ public class MailUtils {
         return new MimeMessage(Session.getInstance(emptyProperties), is);
     }
 
-    private static void collectAddrs(List<Address> dest, Address[] list) {
+    private static void collectAddrs(List<InternetAddress> dest, Address[] list) {
         if (list != null) {
-            dest.addAll(Arrays.asList(list));
+            for (Address addr : list) {
+                if (addr instanceof InternetAddress address) {
+                    dest.add(address);
+                }
+            }
         }
     }
-
-    public static List<Address> getToCCBccAddresses(MimeMessage message) {
-        List<Address> addressList = new ArrayList<>();
+    public static List<InternetAddress> getToCCBccAddresses(MimeMessage message) {
+        List<InternetAddress> addressList = new ArrayList<>();
         try {
             collectAddrs(addressList, message.getRecipients(MimeMessage.RecipientType.TO));
             collectAddrs(addressList, message.getRecipients(MimeMessage.RecipientType.CC));

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ buildscript {
     ext {
         agp_version = '8.5.0'
         kotlin_version = '1.9.25'
-        appVersionCode = 5
-        appVersionName = '0.1-alpha3R3'
+        appVersionCode = 6
+        appVersionName = '0.2-alpha1'
     }
     repositories {
         google()

--- a/bundle-core/src/main/java/net/discdd/client/applicationdatamanager/ApplicationDataManager.java
+++ b/bundle-core/src/main/java/net/discdd/client/applicationdatamanager/ApplicationDataManager.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.INFO;
@@ -34,12 +35,10 @@ public class ApplicationDataManager {
 
     private static final Logger logger = Logger.getLogger(ApplicationDataManager.class.getName());
 
-    private StoreADUs sendADUsStorage;
-    private StoreADUs receiveADUsStorage;
+    public final StoreADUs sendADUsStorage;
+    public final StoreADUs receiveADUsStorage;
     private Consumer<ADU> aduConsumer;
     /* Database tables */
-
-    private static List<String> REGISTER_APP_IDS = List.of("com.example.mysignal", "net.discdd.k9", "testAppId");
 
     private ClientPaths clientPaths;
 
@@ -61,7 +60,9 @@ public class ApplicationDataManager {
     }
 
     public List<String> getRegisteredAppIds() throws IOException {
-        return REGISTER_APP_IDS;
+        return sendADUsStorage.getAllClientApps(true)
+                .map(StoreADUs.ClientApp::appId)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     public void processAcknowledgement(String bundleId) {

--- a/bundle-core/src/main/java/net/discdd/client/applicationdatamanager/ApplicationDataManager.java
+++ b/bundle-core/src/main/java/net/discdd/client/applicationdatamanager/ApplicationDataManager.java
@@ -91,9 +91,9 @@ public class ApplicationDataManager {
         for (final ADU adu : adus) {
             try {
                 var aduFile = receiveADUsStorage.addADU(null,
-                                          adu.getAppId(),
-                                          Files.readAllBytes(adu.getSource().toPath()),
-                                          adu.getADUId());
+                                                        adu.getAppId(),
+                                                        Files.readAllBytes(adu.getSource().toPath()),
+                                                        adu.getADUId());
                 // if aduFile == null, the ADU was not added
                 if (aduFile != null) {
                     aduConsumer.accept(adu);

--- a/bundle-core/src/main/java/net/discdd/client/applicationdatamanager/ApplicationDataManager.java
+++ b/bundle-core/src/main/java/net/discdd/client/applicationdatamanager/ApplicationDataManager.java
@@ -88,20 +88,23 @@ public class ApplicationDataManager {
 
     public void storeReceivedADUs(String clientId, String bundleId, List<ADU> adus) {
         logger.log(INFO, "[ADM] Storing ADUs in the Data Store, Size:" + adus.size());
-
         for (final ADU adu : adus) {
-
             try {
-                receiveADUsStorage.addADU(null,
+                var aduFile = receiveADUsStorage.addADU(null,
                                           adu.getAppId(),
                                           Files.readAllBytes(adu.getSource().toPath()),
                                           adu.getADUId());
-                aduConsumer.accept(adu);
+                // if aduFile == null, the ADU was not added
+                if (aduFile != null) {
+                    aduConsumer.accept(adu);
+                }
                 logger.log(FINE, "[ADM] Updated Largest ADU id: " + adu.getADUId() + "," + adu.getSource());
             } catch (IOException e) {
                 logger.log(WARNING, "Could not persist adu: " + adu.getADUId(), e);
             }
         }
+        // this indicates that the batch of ADUs has been finished
+        aduConsumer.accept(null);
     }
 
     public List<ADU> fetchADUsToSend(long initialSize, String clientId) throws IOException {

--- a/bundle-core/src/main/java/net/discdd/client/bundlesecurity/ClientSecurity.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundlesecurity/ClientSecurity.java
@@ -243,10 +243,8 @@ public class ClientSecurity {
 
         String payloadName = SecurityUtils.PAYLOAD_FILENAME;
 
-        try (
-                InputStream encryptedDataInputStream = Files.newInputStream(payloadPath.resolve(payloadName));
-                OutputStream encryptedDataOutputStream = Files.newOutputStream(decryptedFile)
-        ){
+        try (InputStream encryptedDataInputStream = Files.newInputStream(payloadPath.resolve(payloadName));
+             OutputStream encryptedDataOutputStream = Files.newOutputStream(decryptedFile)) {
             cipherSession.decrypt(encryptedDataInputStream, encryptedDataOutputStream);
             updateSessionRecord();
         }

--- a/bundle-core/src/main/java/net/discdd/client/bundlesecurity/ClientSecurity.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundlesecurity/ClientSecurity.java
@@ -243,10 +243,13 @@ public class ClientSecurity {
 
         String payloadName = SecurityUtils.PAYLOAD_FILENAME;
 
-        InputStream encryptedDataInputStream = Files.newInputStream(payloadPath.resolve(payloadName));
-        OutputStream encryptedDataOutputStream = Files.newOutputStream(decryptedFile);
-        cipherSession.decrypt(encryptedDataInputStream, encryptedDataOutputStream);
-        updateSessionRecord();
+        try (
+                InputStream encryptedDataInputStream = Files.newInputStream(payloadPath.resolve(payloadName));
+                OutputStream encryptedDataOutputStream = Files.newOutputStream(decryptedFile)
+        ){
+            cipherSession.decrypt(encryptedDataInputStream, encryptedDataOutputStream);
+            updateSessionRecord();
+        }
 
         logger.log(FINER, "Decrypted Size = %d\n", Files.size(decryptedPath));
     }

--- a/bundle-core/src/main/java/net/discdd/client/bundletransmission/BundleTransmission.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundletransmission/BundleTransmission.java
@@ -86,7 +86,7 @@ public class BundleTransmission {
     private static final Logger logger = Logger.getLogger(BundleTransmission.class.getName());
     private final ExecutorService executorService = Executors.newCachedThreadPool();
     private final BundleSecurity bundleSecurity;
-    private final ApplicationDataManager applicationDataManager;
+    public final ApplicationDataManager applicationDataManager;
 
     private ClientRouting clientRouting;
     private ClientPaths clientPaths;

--- a/bundle-core/src/main/java/net/discdd/utils/BundleUtils.java
+++ b/bundle-core/src/main/java/net/discdd/utils/BundleUtils.java
@@ -315,25 +315,25 @@ public class BundleUtils {
                                                   String crashReport,
                                                   OutputStream outputStream) throws IOException,
             NoSuchAlgorithmException {
-        DDDJarFileCreator innerJar = new DDDJarFileCreator(outputStream);
-        if (ackedEncryptedBundleId == null) ackedEncryptedBundleId = "HB";
-        logger.log(INFO, "[BU/createBundlePayload] " + adus.size());
-        // add the records to the inner jar
-        innerJar.createEntry("acknowledgement.txt", ackedEncryptedBundleId.getBytes());
-        innerJar.createEntry("routing.metadata", routingData == null ? "{}".getBytes() : routingData);
-        if (crashReport != null) {
-            innerJar.createEntry("crash_report.txt", crashReport.getBytes());
-        }
+        try (DDDJarFileCreator innerJar = new DDDJarFileCreator(outputStream)) {
+            if (ackedEncryptedBundleId == null) ackedEncryptedBundleId = "HB";
+            logger.log(INFO, "[BU/createBundlePayload] " + adus.size());
+            // add the records to the inner jar
+            innerJar.createEntry("acknowledgement.txt", ackedEncryptedBundleId.getBytes());
+            innerJar.createEntry("routing.metadata", routingData == null ? "{}".getBytes() : routingData);
+            if (crashReport != null) {
+                innerJar.createEntry("crash_report.txt", crashReport.getBytes());
+            }
 
-        for (var adu : adus) {
-            try (var os = innerJar.createEntry(Paths.get(Constants.BUNDLE_ADU_DIRECTORY_NAME,
-                                                         adu.getAppId(),
-                                                         Long.toString(adu.getADUId())));
-                 var aos = Files.newInputStream(adu.getSource().toPath(), StandardOpenOption.READ)) {
-                aos.transferTo(os);
+            for (var adu : adus) {
+                try (var os = innerJar.createEntry(Paths.get(Constants.BUNDLE_ADU_DIRECTORY_NAME,
+                                                             adu.getAppId(),
+                                                             Long.toString(adu.getADUId())));
+                     var aos = Files.newInputStream(adu.getSource().toPath(), StandardOpenOption.READ)) {
+                    aos.transferTo(os);
+                }
             }
         }
-        innerJar.close();
     }
 
     public static void encryptPayloadAndCreateBundle(Encrypter payloadEncryptor,

--- a/bundle-core/src/main/java/net/discdd/utils/DDDJarFileCreator.java
+++ b/bundle-core/src/main/java/net/discdd/utils/DDDJarFileCreator.java
@@ -14,7 +14,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 
-public class DDDJarFileCreator {
+public class DDDJarFileCreator implements AutoCloseable {
     private static final String SHA256_ATTRIBUTE_NAME = "SHA-256-Digest";
     final private JarOutputStream jarOutputStream;
     final private Manifest manifest = new Manifest();

--- a/bundle-core/src/main/java/net/discdd/utils/StoreADUs.java
+++ b/bundle-core/src/main/java/net/discdd/utils/StoreADUs.java
@@ -246,16 +246,17 @@ public class StoreADUs {
 
     /**
      * Add an ADU to the store.
+     *
      * @param clientId the client ID, can be null if there is only one client (for BundleClient mainly)
-     * @param appId the application ID of the ADU
-     * @param data the data to write to the ADU
-     * @param aduId if less than 0 we will set to next ID on the last write (when finished is true)
-     * @param offset the offset in the file where to write the data. Normally this is 0, but it can be
-     *               used to append data
+     * @param appId    the application ID of the ADU
+     * @param data     the data to write to the ADU
+     * @param aduId    if less than 0 we will set to next ID on the last write (when finished is true)
+     * @param offset   the offset in the file where to write the data. Normally this is 0, but it can be
+     *                 used to append data
      * @param finished if null or true, the ADU will not be written to again. (If the aduId was given as a negative
      *                 number, it will be set to the last ADU ID added and the file will be moved to the new location.)
      * @return the file where the ADU was written, or null if the ADU was skipped because the id is less
-     *         than or equal to the last deleted ADU ID.
+     * than or equal to the last deleted ADU ID.
      * @throws IOException if there is an error writing the ADU to the file system
      */
     public File addADU(String clientId, String appId, byte[] data, long aduId, long offset, Boolean finished) throws

--- a/bundle-core/src/main/java/net/discdd/utils/StoreADUs.java
+++ b/bundle-core/src/main/java/net/discdd/utils/StoreADUs.java
@@ -128,12 +128,12 @@ public class StoreADUs {
         return getAllClientApps(false);
     }
 
-        /**
-         * Get all client applications in the store.
-         *
-         * @param singleClientId if true, there are no client IDs in the path, and the store is used by a single client
-         * @return a stream of ClientApp objects representing all client applications
-         */
+    /**
+     * Get all client applications in the store.
+     *
+     * @param singleClientId if true, there are no client IDs in the path, and the store is used by a single client
+     * @return a stream of ClientApp objects representing all client applications
+     */
     public Stream<ClientApp> getAllClientApps(boolean singleClientId) {
         try {
             ArrayList<Path> topPaths = new ArrayList<>();
@@ -150,7 +150,8 @@ public class StoreADUs {
                         return bottomPaths.map(Path::toFile)
                                 .filter(File::isDirectory)
                                 .map(File::getName)
-                                .map(appId -> new ClientApp(singleClientId ? "" : clientIdPath.toFile().getName(), appId))
+                                .map(appId -> new ClientApp(singleClientId ? "" : clientIdPath.toFile().getName(),
+                                                            appId))
                                 .collect(Collectors.toUnmodifiableList())
                                 .stream();
                     }

--- a/client-adapter/build.gradle
+++ b/client-adapter/build.gradle
@@ -35,17 +35,24 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }
 
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    archiveClassifier.set('sources')
+}
+
 publishing {
     publications {
         release(MavenPublication) {
             groupId = 'net.discdd'
             artifactId = 'client-adapter'
-            version = '0.0.1-SNAPSHOT'
+            version = '0.2.0-SNAPSHOT'
             artifact("$buildDir/outputs/aar/${project.name}-release.aar")
+            artifact(sourcesJar)
         }
     }
 
     repositories {
+        mavenLocal()
         maven {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/SJSU-CS-systems-group/DDD")

--- a/client-adapter/src/main/AndroidManifest.xml
+++ b/client-adapter/src/main/AndroidManifest.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission
-            android:name="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_READ"
-            android:protectionLevel="normal" />
-    <uses-permission
-            android:name="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_WRITE"
-            android:protectionLevel="normal" />
-
     <queries>
         <provider android:authorities="net.discdd.provider.datastoreprovider" />
     </queries>
-
 </manifest>

--- a/client-adapter/src/main/java/net/discdd/adapter/DDDClientAdapter.java
+++ b/client-adapter/src/main/java/net/discdd/adapter/DDDClientAdapter.java
@@ -12,7 +12,6 @@ import android.net.Uri;
 import android.util.Log;
 import androidx.annotation.NonNull;
 
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -25,9 +24,11 @@ import static java.lang.String.format;
 public class DDDClientAdapter extends BroadcastReceiver {
     public static final String PROVIDER_NAME = "net.discdd.provider.datastoreprovider";
     public static final Uri PROVIDER_URI;
+
     static {
         PROVIDER_URI = Uri.parse(format("content://%s/messages", PROVIDER_NAME));
     }
+
     public static final int MAX_ADU_SIZE = 512 * 1024;
 
     final Context context;
@@ -58,12 +59,13 @@ public class DDDClientAdapter extends BroadcastReceiver {
             contentObserver = new ContentObserver(null) {
                 @Override
                 public void onChange(boolean selfChange) {
-                    Log.i("DDDClientAdapter","ContentObserver onChange called without URI (should not happen)");
+                    Log.i("DDDClientAdapter", "ContentObserver onChange called without URI (should not happen)");
                     onAdusReceived.run();
                 }
+
                 @Override
                 public void onChange(boolean selfChange, @NonNull Uri uri) {
-                    Log.i("DDDClientAdapter","ContentObserver onChange called for URI: " + uri);
+                    Log.i("DDDClientAdapter", "ContentObserver onChange called for URI: " + uri);
                     onAdusReceived.run();
                 }
             };


### PR DESCRIPTION
Nonfunctional USB tab

When I first download transport app and plug in USB, reload button becomes unreactive (must close and re-open transport to see the document tree launcher but then “Allow” button from “Use this folder” button becomes completely unreactive as well and phone never finds the ddd directory)

I made this draft to more easily identify where change causing this issue may be (but many previous commits were added as well)