### PR TITLE
fix bundle server acknowledgements and ADU tracking

### DIFF
--- a/bundleserver/src/main/java/net/discdd/server/bundletransmission/BundleTransmission.java
+++ b/bundleserver/src/main/java/net/discdd/server/bundletransmission/BundleTransmission.java
@@ -10,7 +10,6 @@ import net.discdd.grpc.BundleSenderType;
 import net.discdd.grpc.GetRecencyBlobResponse;
 import net.discdd.grpc.RecencyBlob;
 import net.discdd.grpc.RecencyBlobStatus;
-import net.discdd.model.ADU;
 import net.discdd.model.Bundle;
 import net.discdd.model.Payload;
 import net.discdd.model.UncompressedBundle;
@@ -30,12 +29,10 @@ import org.whispersystems.libsignal.InvalidMessageException;
 import java.io.File;
 import java.io.IOException;
 import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -55,7 +52,6 @@ import static java.util.logging.Level.WARNING;
 import static net.discdd.bundlesecurity.SecurityUtils.generateID;
 import static net.discdd.grpc.BundleSenderType.CLIENT;
 import static net.discdd.grpc.BundleSenderType.TRANSPORT;
-import static net.discdd.utils.BundleUtils.runFuture;
 
 @Service
 public class BundleTransmission {
@@ -204,9 +200,9 @@ public class BundleTransmission {
         long ackedRecievedBundle = counts.lastReceivedBundleCounter;
         applicationDataManager.registerNewBundleId(clientId, encryptedBundleId, bundleCounter, ackedRecievedBundle);
 
-        var adus = applicationDataManager.fetchADUsToSend(0, clientId);
+        var adus = applicationDataManager.fetchADUsToSend(encryptedBundleId, bundleCounter, 0, clientId);
         PipedInputStream pipedInputStream = new PipedInputStream();
-        Future<?> future = BundleUtils.runFuture(executorService, null, null, adus, null, pipedInputStream);
+        Future<?> future = BundleUtils.runFuture(executorService, counts.lastReceivedBundleId, null, adus, null, pipedInputStream);
         try {
             var bundleOutputStream = Files.newOutputStream(getPathForBundleToSend(encryptedBundleId),
                                                            StandardOpenOption.CREATE,


### PR DESCRIPTION
the bundle server wasn't correctly tracking the ADUs stored in a bundle, which meant that the ADUs were never deleted on the server. it also was not acknowledging the last bundle received, which meant that the client was not cleaning up sent ADUs.