### PR TITLE
makes sure grpc calls go through a transaction

### DIFF
--- a/apps/k9/server/src/main/java/net/discdd/app/k9/K9Application.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/K9Application.java
@@ -3,15 +3,18 @@ package net.discdd.app.k9;
 import net.discdd.config.GrpcSecurityConfig;
 import net.discdd.grpc.AdapterRegisterService;
 import net.discdd.grpc.GrpcServerRunner;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.concurrent.Executor;
 import java.util.logging.Logger;
 
 /*

--- a/apps/k9/server/src/main/java/net/discdd/app/k9/K9Config.java
+++ b/apps/k9/server/src/main/java/net/discdd/app/k9/K9Config.java
@@ -1,16 +1,34 @@
 package net.discdd.app.k9;
 
 import net.discdd.utils.StoreADUs;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
-@Configuration
+@Component
 public class K9Config {
     @Bean
     public StoreADUs sendStoreADUs(@Value("${adapter-server.rootdir}") Path rootDir) {
         return new StoreADUs(rootDir.resolve("send"), true);
+    }
+
+    @Bean(name = "grpcExecutor")
+    public Executor grpcExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(100);
+        executor.initialize();
+        return executor;
     }
 }

--- a/bundle-core/src/main/java/net/discdd/tls/DDDNettyTLS.java
+++ b/bundle-core/src/main/java/net/discdd/tls/DDDNettyTLS.java
@@ -14,11 +14,12 @@ import javax.net.ssl.SSLException;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 public class DDDNettyTLS {
-
-    public static Server createGrpcServer(KeyPair serverKeyPair,
+    public static Server createGrpcServer(Executor executor,
+                                          KeyPair serverKeyPair,
                                           X509Certificate serverCert,
                                           int port,
                                           BindableService... services) throws SSLException {
@@ -33,7 +34,7 @@ public class DDDNettyTLS {
         for (var service : services) {
             serviceBuilder.addService(service);
         }
-
+        serviceBuilder.executor(executor);
         serviceBuilder.intercept(new NettyServerCertificateInterceptor());
         return serviceBuilder.build();
     }

--- a/bundleserver/src/main/java/net/discdd/server/service/GrpcExecutor.java
+++ b/bundleserver/src/main/java/net/discdd/server/service/GrpcExecutor.java
@@ -1,0 +1,54 @@
+package net.discdd.server.service;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.Executor;
+
+/**
+ * This crazy code is used to execute gRPC calls in a transactional context.
+ * Without it, code will mostly work, but some database operations will fail.
+ */
+@Component
+@Qualifier("grpcExecutor")
+public class GrpcExecutor implements Executor {
+    // use a Spring-managed ThreadPoolTaskExecutor to handle gRPC calls
+    private final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    // this loooks really weird since the implementation is in this class! but ...
+    // ... after a ton of chatGPTing ... reading doc ... debugging ... i landed on
+    // this solution. key requirements:
+    // 1. Runnables run in a spring executor
+    // 2. They pass through a @Transactional method
+    // 3. That transactional method is on a Spring-managed bean (not created with new)
+    // 4. the bean cannot be the executor itself, which seems really weird to me,
+    //    but i experimented with it alot and it doesn't work!
+    private final GrpcTransactionalRunner grpcTransactionalRunner;
+
+    public GrpcExecutor(GrpcTransactionalRunner grpcTransactionalRunner) {
+        this.grpcTransactionalRunner = grpcTransactionalRunner;
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(100);
+        executor.initialize();
+    }
+    @Override
+    public void execute(Runnable command) {
+        try {
+            executor.execute(() -> grpcTransactionalRunner.executeInTransaction(command));
+        } catch (Exception e) {
+            // Log the exception or handle it as needed
+            System.err.println("Error executing command: " + e.getMessage());
+        }
+    }
+
+    @Component
+    public static class GrpcTransactionalRunner {
+        @Transactional
+        public void executeInTransaction(Runnable command) {
+            // This method is used to ensure that the command runs in a transaction
+            command.run();
+        }
+    }
+}


### PR DESCRIPTION
we need to make sure gRPC calls pass through a bean method that is annotated with Transaction so that the database will behave properly. we also need to make sure that DB operations run on spring managed threads.

hopefully this change slays our database change exceptions!