### PR TITLE
added grpc-netty-shaded to service-adapter

### DIFF
--- a/serviceadapter-core/pom.xml
+++ b/serviceadapter-core/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>grpc-protobuf</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>


### PR DESCRIPTION
grpc-netty-shaded makes the TLS work properly with io.grpc. we need all the adapters to use it.