### PR TITLE
remove properties check from ControlAdu

### DIFF
--- a/apps/k9/common/src/test/java/net/discdd/app/k9/common/ControlAduTest.java
+++ b/apps/k9/common/src/test/java/net/discdd/app/k9/common/ControlAduTest.java
@@ -41,16 +41,4 @@ public class ControlAduTest {
         var serDeserWhoAmIAckControlAdu = ControlAdu.fromBytes(origWhoAmIAckControlAdu.toBytes());
         Assertions.assertEquals(origWhoAmIAckControlAdu, serDeserWhoAmIAckControlAdu);
     }
-
-    @Test
-    public void testControlAduExtraData() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            new ControlAdu.LoginControlAdu(Map.of("username",
-                                                  "testuser",
-                                                  "password",
-                                                  "testpass",
-                                                  "extraData",
-                                                  "testdata"));
-        });
-    }
 }


### PR DESCRIPTION
it appears that when classes are minimized, it affects the methods that are available, so we cannot reliably check method names in release builds.