### PR TITLE
reinitialize wifi direct if permissions were missing

### DIFF
--- a/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportHomeScreen.kt
+++ b/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/TransportHomeScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import kotlinx.coroutines.launch
 import net.discdd.UsbConnectionManager
@@ -63,6 +64,12 @@ fun TransportHomeScreen(
     val nearbyWifiState = rememberPermissionState(
             Manifest.permission.NEARBY_WIFI_DEVICES
     )
+    LaunchedEffect(nearbyWifiState.status) {
+        if (nearbyWifiState.status.isGranted) {
+            TransportWifiServiceManager.getService()?.wifiPermissionGranted()
+        }
+    }
+
     val notificationState = rememberPermissionState(Manifest.permission.POST_NOTIFICATIONS,
             onPermissionResult = {
                 viewModel.onFirstOpen()

--- a/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/service/DDDWifiServiceEvents.kt
+++ b/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/service/DDDWifiServiceEvents.kt
@@ -7,7 +7,8 @@ import kotlinx.coroutines.launch
 import net.discdd.bundletransport.wifi.DDDWifiServer
 
 object DDDWifiServiceEvents {
-    val events = MutableSharedFlow<DDDWifiServer.DDDWifiServerEvent>()
+    // some of these events (especially the state events come in bursts, so we need a backlog
+    val events = MutableSharedFlow<DDDWifiServer.DDDWifiServerEvent>(5)
     private val serviceScope = CoroutineScope(Dispatchers.Default)
 
     @JvmStatic

--- a/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/WifiDirectViewModel.kt
+++ b/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/viewmodels/WifiDirectViewModel.kt
@@ -99,10 +99,12 @@ class WifiDirectViewModel(
     }
 
     fun updateGroupInfo() {
-        btService?.dddWifiServer?.networkInfo?.let { ni ->
-            viewModelScope.launch {
-                _state.update {
-                    it.copy(wifiInfo = "SSID: ${ni.ssid}\nPassword: ${ni.password}\nAddress: ${ni.inetAddress}\nConnected devices: ${ni.clientList.size}")
+        viewModelScope.launch {
+            btService?.dddWifiServer?.networkInfo?.let { ni ->
+                viewModelScope.launch {
+                    _state.update {
+                        it.copy(wifiInfo = "SSID: ${ni.ssid}\nPassword: ${ni.password}\nAddress: ${ni.inetAddress}\nConnected devices: ${ni.clientList.size}")
+                    }
                 }
             }
         }

--- a/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/wifi/DDDWifiServer.java
+++ b/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/wifi/DDDWifiServer.java
@@ -41,6 +41,14 @@ public class DDDWifiServer {
     private boolean wifiDirectEnabled;
     private WifiDirectStatus status = WifiDirectStatus.UNDEFINED;
 
+    public void wifiPermissionGranted() {
+        if (channel == null) {
+            initialize();
+        } else if (wifiGroup == null) {
+            createGroup();
+        }
+    }
+
     public enum WifiDirectStatus {FAILED, INVITED, AVAILABLE, UNAVAILABLE, UNDEFINED, CONNECTED}
 
     public DDDWifiServer(Context applicationContext) {


### PR DESCRIPTION
on first startup, the transport background service doesn't have permissions to do wifi direct.
once those permissions are obtained, we notify the background service so that it can retry.