### PR TITLE
delayed start to background transmissions

### DIFF
--- a/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/BundleClientService.java
+++ b/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/BundleClientService.java
@@ -447,7 +447,7 @@ public class BundleClientService extends Service {
         synchronized public void schedule(int minutes) {
             if (scheduledFuture == null) {
                 logger.info(format("Scheduling periodic exchange with transports every %d minutes", minutes));
-                scheduledFuture = periodicExecutor.scheduleWithFixedDelay(this, 0, minutes,
+                scheduledFuture = periodicExecutor.scheduleWithFixedDelay(this, minutes, minutes,
                                                                           TimeUnit.MINUTES);
             }
         }


### PR DESCRIPTION
when scheduling the background transmissions, set the initial delay to the normal delay. with no initial delay, the background transmissions race initialization.