### PR TITLE
bundle transport initial schedule duration

### DIFF
--- a/AndroidApps/android-core/src/main/java/net/discdd/util/DDDFixedRateScheduler.java
+++ b/AndroidApps/android-core/src/main/java/net/discdd/util/DDDFixedRateScheduler.java
@@ -57,7 +57,7 @@ public class DDDFixedRateScheduler<T> {
             } finally {
                 lastExecutionFinish = System.currentTimeMillis();
             }
-        }, 0, periodInMinutes, TimeUnit.MINUTES);
+        }, periodInMinutes, periodInMinutes, TimeUnit.MINUTES);
     }
 
     /**


### PR DESCRIPTION
we need the background scheduler initial delay to be the duration to avoid racing with initialization of everything.