### PR TITLE
fixed early bundle removal in bundle server

### DIFF
--- a/bundle-core/src/main/java/net/discdd/bundlerouting/service/BundleExchangeServiceImpl.java
+++ b/bundle-core/src/main/java/net/discdd/bundlerouting/service/BundleExchangeServiceImpl.java
@@ -54,6 +54,7 @@ public abstract class BundleExchangeServiceImpl extends BundleExchangeServiceGrp
                                 pathProducer(bundleExchangeName, request.getSenderType(), null);
 
             if (downloadPath == null) {
+                logger.log(SEVERE, "Could not produce a path for " + bundleExchangeName.encryptedBundleId + " with map " + request.getPublicKeyMap());
                 responseObserver.onError(io.grpc.Status.NOT_FOUND.withDescription("Bundle not found").asException());
                 return;
             }

--- a/bundle-core/src/main/java/net/discdd/bundlerouting/service/BundleExchangeServiceImpl.java
+++ b/bundle-core/src/main/java/net/discdd/bundlerouting/service/BundleExchangeServiceImpl.java
@@ -67,7 +67,6 @@ public abstract class BundleExchangeServiceImpl extends BundleExchangeServiceGrp
                                                                                             .build())
                                                                           .build()));
             }
-            Files.delete(downloadPath);
             logger.log(INFO, "Complete " + request.getBundleId().getEncryptedId());
             responseObserver.onCompleted();
         } catch (Exception e) {

--- a/bundleserver/src/main/java/net/discdd/server/applicationdatamanager/ApplicationDataManager.java
+++ b/bundleserver/src/main/java/net/discdd/server/applicationdatamanager/ApplicationDataManager.java
@@ -1,7 +1,6 @@
 package net.discdd.server.applicationdatamanager;
 
 import net.discdd.model.ADU;
-import net.discdd.model.UncompressedPayload;
 import net.discdd.server.config.BundleServerConfig;
 import net.discdd.server.repository.BundleMetadataRepository;
 import net.discdd.server.repository.ClientBundleCountersRepository;
@@ -10,11 +9,9 @@ import net.discdd.server.repository.SentAduDetailsRepository;
 import net.discdd.server.repository.entity.BundleMetadata;
 import net.discdd.server.repository.entity.ClientBundleCounters;
 import net.discdd.server.repository.entity.SentAduDetails;
-import net.discdd.utils.BundleUtils;
 import net.discdd.utils.StoreADUs;
 import org.springframework.stereotype.Service;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -22,7 +19,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Logger;

--- a/bundleserver/src/main/java/net/discdd/server/applicationdatamanager/ApplicationDataManager.java
+++ b/bundleserver/src/main/java/net/discdd/server/applicationdatamanager/ApplicationDataManager.java
@@ -77,7 +77,7 @@ public class ApplicationDataManager {
         sentAduDetailsRepository.deleteByBundleId(bundleId);
 
         logger.log(INFO,
-                   "[StateManager] Processed acknowledgement for sent bundle id " + bundleId +
+                   "[StateManager] Processed acknowledgement and deleted bundle id " + bundleId +
                            " corresponding to client " + clientId);
     }
 

--- a/bundleserver/src/main/java/net/discdd/server/bundletransmission/BundleTransmission.java
+++ b/bundleserver/src/main/java/net/discdd/server/bundletransmission/BundleTransmission.java
@@ -227,6 +227,8 @@ public class BundleTransmission {
         } finally {
             future.cancel(true);
         }
+        logger.log(INFO, "Bundle generated for client " + clientId + " with ID: " +
+                encryptedBundleId + " in " + getPathForBundleToSend(encryptedBundleId));
         return encryptedBundleId;
     }
 

--- a/bundleserver/src/main/java/net/discdd/server/bundletransmission/BundleTransmission.java
+++ b/bundleserver/src/main/java/net/discdd/server/bundletransmission/BundleTransmission.java
@@ -19,6 +19,7 @@ import net.discdd.server.bundlerouting.BundleRouting;
 import net.discdd.server.bundlerouting.ServerWindowService;
 import net.discdd.server.bundlesecurity.BundleSecurity;
 import net.discdd.server.config.BundleServerConfig;
+import net.discdd.server.repository.entity.ClientBundleCounters;
 import net.discdd.utils.BundleUtils;
 import net.discdd.utils.FileUtils;
 import org.springframework.scheduling.annotation.Async;
@@ -187,11 +188,13 @@ public class BundleTransmission {
             InvalidKeyException, IOException {
         logger.log(INFO, "[BundleTransmission] Processing bundle generation request for client " + clientId);
 
+        ClientBundleCounters bundleCountersForClient = this.applicationDataManager.getBundleCountersForClient(clientId);
         if (this.serverWindowService.isWindowFull(clientId)) {
-            return this.applicationDataManager.getBundleCountersForClient(clientId).lastSentBundleId;
+            logger.log(INFO, "Server's window is full for the client " + clientId + " returning last sent bundle ID " + bundleCountersForClient.lastSentBundleId);
+            return bundleCountersForClient.lastSentBundleId;
         }
 
-        var counts = this.applicationDataManager.getBundleCountersForClient(clientId);
+        var counts = bundleCountersForClient;
         if (counts.lastSentBundleCounter > 0 && !applicationDataManager.newDataToSend(counts.lastSentBundleId) &&
                 !applicationDataManager.newAckNeeded(counts.lastSentBundleId)) {
             // Nothing new to send, so lets send the last bundle again.

--- a/bundleserver/src/main/java/net/discdd/server/service/BundleServerExchangeServiceImpl.java
+++ b/bundleserver/src/main/java/net/discdd/server/service/BundleServerExchangeServiceImpl.java
@@ -84,6 +84,10 @@ public class BundleServerExchangeServiceImpl extends BundleExchangeServiceImpl {
 
             bundleTransmission.getPathForBundleToSend(bundleExchangeName.encryptedBundleId());
             var bundlePath = bundleTransmission.getPathForBundleToSend(bundleExchangeName.encryptedBundleId());
+            logger.info(String.format("Path for bundle %s is %s exists %s",
+                                                bundleExchangeName.encryptedBundleId(),
+                                      bundlePath.toString(),
+                                      bundlePath.toFile().exists()));
             if (bundlePath.toFile().exists()) {
                 return bundlePath;
             }

--- a/bundleserver/src/main/java/net/discdd/server/service/BundleServerExchangeServiceImpl.java
+++ b/bundleserver/src/main/java/net/discdd/server/service/BundleServerExchangeServiceImpl.java
@@ -108,7 +108,7 @@ public class BundleServerExchangeServiceImpl extends BundleExchangeServiceImpl {
                 return null;
             } catch (Exception e) {
                 logger.log(SEVERE, "Problem generating bundle for client " + senderId, e);
-                throw new RuntimeException("Problem generating bundle: " + e.getMessage());
+                return null;
             }
         } else {
             byte[] randomBytes = new byte[16];

--- a/bundleserver/src/main/java/net/discdd/server/service/BundleServerServiceImpl.java
+++ b/bundleserver/src/main/java/net/discdd/server/service/BundleServerServiceImpl.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -71,10 +72,10 @@ public class BundleServerServiceImpl extends BundleServerServiceGrpc.BundleServe
         var downloadList = new ArrayList<EncryptedBundleId>();
 
         X509Certificate clientCert = NettyServerCertificateInterceptor.CLIENT_CERTIFICATE_KEY.get(Context.current());
+        String senderId = DDDTLSUtil.publicKeyToName(clientCert.getPublicKey());
         try {
             var bundlesToExchange = bundleTransmission.inventoryBundlesForTransmission(request.getSenderType(),
-                                                                                       DDDTLSUtil.publicKeyToName(
-                                                                                               clientCert.getPublicKey()),
+                                                                                       senderId,
                                                                                        serverBundlesOnTransport);
             bundlesToExchange.bundlesToDelete()
                     .stream()
@@ -92,8 +93,20 @@ public class BundleServerServiceImpl extends BundleServerServiceGrpc.BundleServe
                 .addAllBundlesToDownload(downloadList)
                 .addAllBundlesToUpload(request.getBundlesFromClientsOnTransportList())
                 .build();
+        logger.info(String.format("%s to delete %s download %s upload %s",
+                                  senderId,
+                                  bundleListToString(inventoryResponse.getBundlesToDeleteList()),
+                                  bundleListToString(inventoryResponse.getBundlesToDownloadList()),
+                                  bundleListToString(inventoryResponse.getBundlesToUploadList())
+        ));
         responseObserver.onNext(inventoryResponse);
         responseObserver.onCompleted();
+    }
+
+    static private String bundleListToString(List<EncryptedBundleId> bundleList) {
+        return bundleList.stream()
+                .map(EncryptedBundleId::getEncryptedId)
+                .collect(Collectors.joining(","));
     }
 
     @Override


### PR DESCRIPTION
* sent bundles should be removed when they are acknowledged, not when they are downloaded by the transport.
* enhance logging of bundle download process