### PR TITLE
make sure background service is only started once

### DIFF
--- a/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/BundleClientService.java
+++ b/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/BundleClientService.java
@@ -110,6 +110,10 @@ public class BundleClientService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         super.onStartCommand(intent, flags, startId);
+        if (preferences != null) {
+            // if preferences are initialized, everything else should be too
+            return START_STICKY;
+        }
         preferences = getSharedPreferences(NET_DISCDD_BUNDLECLIENT_SETTINGS, MODE_PRIVATE);
         preferences.registerOnSharedPreferenceChangeListener(onSharedPreferenceChangeListener);
         fixedRateSched = new DDDFixedRateScheduler<>(getApplicationContext(), this::exchangeWithTransports);

--- a/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportService.java
+++ b/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/BundleTransportService.java
@@ -123,6 +123,10 @@ public class BundleTransportService extends Service implements BundleExchangeSer
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         super.onStartCommand(intent, flags, startId);
+        if (transportPaths != null) {
+            // If the transport paths are already initialized, we don't need to reinitialize them
+            return START_STICKY;
+        }
         this.transportPaths = new TransportPaths(getApplicationContext().getExternalFilesDir(null).toPath());
         try {
             this.grpcKeys = new GrpcSecurityKey(transportPaths.grpcSecurityPath, SecurityUtils.SERVER);


### PR DESCRIPTION
the activities may try to repeatedly start the background service, but it should only be started once.