### PR TITLE
only require NEARBY_WIFI_DEVICES permission to enable wifip2p

### DIFF
--- a/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/wifiDirect/DDDWifiDirect.java
+++ b/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/wifiDirect/DDDWifiDirect.java
@@ -70,10 +70,9 @@ public class DDDWifiDirect implements DDDWifi {
     private boolean wifiEnable;
 
     private boolean hasPermission() {
-        return ActivityCompat.checkSelfPermission(bundleClientService.getApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) ==
-                PackageManager.PERMISSION_GRANTED &&
-                ActivityCompat.checkSelfPermission(bundleClientService.getApplicationContext(), Manifest.permission.NEARBY_WIFI_DEVICES) ==
-                        PackageManager.PERMISSION_GRANTED;
+        int nearbyWifiPermissionCheck = ActivityCompat.checkSelfPermission(bundleClientService.getApplicationContext(),
+                                                                           Manifest.permission.NEARBY_WIFI_DEVICES);
+        return nearbyWifiPermissionCheck == PackageManager.PERMISSION_GRANTED;
     }
 
     private class DDDWifiDirectBroadcastReceiver extends BroadcastReceiver {

--- a/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/wifi/DDDWifiServer.java
+++ b/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/wifi/DDDWifiServer.java
@@ -148,9 +148,7 @@ public class DDDWifiServer {
     }
 
     private boolean hasPermission() {
-        return ActivityCompat.checkSelfPermission(this.bts, Manifest.permission.ACCESS_FINE_LOCATION) ==
-                PackageManager.PERMISSION_GRANTED ||
-                ActivityCompat.checkSelfPermission(this.bts, Manifest.permission.NEARBY_WIFI_DEVICES) ==
+        return ActivityCompat.checkSelfPermission(this.bts, Manifest.permission.NEARBY_WIFI_DEVICES) ==
                         PackageManager.PERMISSION_GRANTED;
     }
 


### PR DESCRIPTION
we don't need the location permission on android 33+ which is what we are targetting.