### PR TITLE
App share fix to display QR when wifi direct or internet is availableApp share fix

### DIFF
--- a/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/AppShareScreen.kt
+++ b/AndroidApps/BundleTransport/app/src/main/java/net/discdd/bundletransport/screens/AppShareScreen.kt
@@ -62,7 +62,7 @@ fun AppShareScreen(
                         style = MaterialTheme.typography.titleMedium,
                         modifier = Modifier.padding(bottom = 16.dp)
                 )
-            } else if (isNetworkValid()) {
+            } else {
                 if (!appsAvailable) {
                     Text(
                             text = "Download APK files first to enable app sharing",
@@ -73,7 +73,7 @@ fun AppShareScreen(
                     // the QR codes more and makes them easier to scan
                     DownloadButton(appShareViewModel)
                     Text(text = " ")
-                } else {
+                } else if(isNetworkValid()) {
                     wifiConnectURL?.also {
                         QRCodeDisplay("QR code to connect your phone to this transport", it)
                     }


### PR DESCRIPTION
Fix for https://github.com/SJSU-CS-systems-group/DDD/issues/696

The QR code in App Share was disappearing when internet was turned off, even though Wi-Fi Direct was still active. Now the QR code stays visible as long as Wi-Fi Direct is active and an interface with IP starting with `192.168.49.` is present.