### PR TITLE
Lombok fix for Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <lombok.version>1.18.36</lombok.version>
+        <lombok.version>1.18.42</lombok.version>
         <protobuf-plugin.version>3.4.2</protobuf-plugin.version>
         <!-- careful! this version must be compatible with io.grpc -->
         <protobuf.version>4.31.1</protobuf.version>


### PR DESCRIPTION
Updated Lombok version from .36 to .42 to add java 25 compatibility.