### PR TITLE
remove redundant variable ourOneTimePreKey

### DIFF
--- a/bundle-core/src/main/java/net/discdd/bundlesecurity/ServerSecurity.java
+++ b/bundle-core/src/main/java/net/discdd/bundlesecurity/ServerSecurity.java
@@ -51,7 +51,6 @@ public class ServerSecurity {
     private SignalProtocolAddress ourAddress;
     private IdentityKeyPair ourIdentityKeyPair;
     private ECKeyPair ourSignedPreKey;
-    private Optional<ECKeyPair> ourOneTimePreKey;
     private ECKeyPair ourRatchetKey;
     private Path serverRootPath;
     private Path clientRootPath;
@@ -74,7 +73,6 @@ public class ServerSecurity {
             String name = DEFAULT_SERVER_NAME;
             name = SecurityUtils.generateID(ourIdentityKeyPair.getPublicKey().serialize());
             ourAddress = new SignalProtocolAddress(name, ServerDeviceID);
-            ourOneTimePreKey = Optional.absent();
 
             clientRootPath = serverRootPath.resolve("Clients");
             clientRootPath.toFile().mkdirs();


### PR DESCRIPTION
issue #721 
removed ourOneTimePreKey (value was always Optional.absent()) since we have .setOurOneTimePreKey(Optional.absent()) either way