### PR TITLE
Revert "Randomizing zero iv for aes cbc (#734)"

### DIFF
--- a/bundle-core/src/main/java/net/discdd/bundlesecurity/DDDPEMEncoder.java
+++ b/bundle-core/src/main/java/net/discdd/bundlesecurity/DDDPEMEncoder.java
@@ -105,10 +105,8 @@ public class DDDPEMEncoder {
         ECKeyPair ephemeralKeyPair = Curve.generateKeyPair();
         byte[] agreement = Curve.calculateAgreement(serverIdentityPublicKey, ephemeralKeyPair.getPrivateKey());
         String sharedSecret = Base64.getEncoder().encodeToString(agreement);
-        String encryptedClientPubKey = encryptAesCbcPkcs5(sharedSecret,
-                                                          Base64.getEncoder()
-                                                                  .encodeToString(clientPublicKey.serialize()),
-                                                          false);
+        String encryptedClientPubKey =
+                encryptAesCbcPkcs5(sharedSecret, Base64.getEncoder().encodeToString(clientPublicKey.serialize()));
         return (EC_ENCRYPTED_PUBLIC_KEY_HEADER + "\n" +
                 Base64.getUrlEncoder().encodeToString(encryptedClientPubKey.getBytes()) + "\n" +
                 Base64.getUrlEncoder().encodeToString(ephemeralKeyPair.getPublicKey().serialize()) + "\n" +

--- a/bundle-core/src/main/java/net/discdd/bundlesecurity/SecurityUtils.java
+++ b/bundle-core/src/main/java/net/discdd/bundlesecurity/SecurityUtils.java
@@ -15,7 +15,6 @@ import org.whispersystems.libsignal.util.KeyHelper;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -32,10 +31,8 @@ import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
@@ -156,23 +153,17 @@ public class SecurityUtils {
         return generateID(publicKey);
     }
 
-    public static String encryptAesCbcPkcs5(String sharedSecret, String plainText, boolean isBundleID) throws
-            NoSuchAlgorithmException, InvalidKeySpecException, NoSuchPaddingException,
-            InvalidAlgorithmParameterException, java.security.InvalidKeyException, IllegalBlockSizeException,
-            BadPaddingException {
+    public static String encryptAesCbcPkcs5(String sharedSecret, String plainText) throws NoSuchAlgorithmException,
+            InvalidKeySpecException, NoSuchPaddingException, InvalidAlgorithmParameterException,
+            java.security.InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
         byte[] iv = new byte[16];
-        if (isBundleID) {
-            // encrypting the same plaintext with the same key always yields the same ciphertext.
-            // Used for bundle ID encryption where client and server must independently compute matching IDs.
-            Mac mac = Mac.getInstance("HmacSHA256");
-            mac.init(new SecretKeySpec(sharedSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
-            iv = Arrays.copyOf(mac.doFinal(plainText.getBytes(StandardCharsets.UTF_8)), 16);
-        } else {
-            SecureRandom random = new SecureRandom();
-            random.nextBytes(iv);
-        }
+        byte[] encryptedData = null;
 
-        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        /* Create SecretKeyFactory object */
+        SecretKeyFactory factory;
+        factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+
+        /* Create KeySpec object */
         KeySpec spec = new PBEKeySpec(sharedSecret.toCharArray(), sharedSecret.getBytes(), ITERATIONS, KEYLEN);
         SecretKey skey = factory.generateSecret(spec);
         SecretKeySpec secretKeySpec = new SecretKeySpec(skey.getEncoded(), "AES");
@@ -180,17 +171,14 @@ public class SecurityUtils {
         Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
         cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, new IvParameterSpec(iv));
 
-        byte[] encryptedData = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+        encryptedData = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
 
-        byte[] combined = new byte[iv.length + encryptedData.length];
-        System.arraycopy(iv, 0, combined, 0, iv.length);
-        System.arraycopy(encryptedData, 0, combined, iv.length, encryptedData.length);
-
-        return Base64.getUrlEncoder().encodeToString(combined);
+        return Base64.getUrlEncoder().encodeToString(encryptedData);
     }
 
     public static byte[] decryptAesCbcPkcs5(String sharedSecret, String cipherText) throws GeneralSecurityException {
-        byte[] allData = Base64.getUrlDecoder().decode(cipherText);
+        byte[] iv = new byte[16];
+        byte[] encryptedData = Base64.getUrlDecoder().decode(cipherText);
 
         /* Create SecretKeyFactory object */
         SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
@@ -200,19 +188,9 @@ public class SecurityUtils {
         SecretKeySpec secretKeySpec = new SecretKeySpec(skey.getEncoded(), "AES");
 
         Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, new IvParameterSpec(iv));
 
-        // New format: first 16 bytes are the IV, remainder is ciphertext
-        byte[] iv = Arrays.copyOfRange(allData, 0, 16);
-        byte[] encryptedData = Arrays.copyOfRange(allData, 16, allData.length);
-
-        try {
-            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, new IvParameterSpec(iv));
-            return cipher.doFinal(encryptedData);
-        } catch (BadPaddingException e) {
-            // Fallback for legacy data encrypted with a zero IV
-            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, new IvParameterSpec(new byte[16]));
-            return cipher.doFinal(allData);
-        }
+        return cipher.doFinal(encryptedData);
     }
 
     public static String unzip(String zipFilePath) throws IOException {

--- a/bundle-core/src/main/java/net/discdd/bundlesecurity/ServerSecurity.java
+++ b/bundle-core/src/main/java/net/discdd/bundlesecurity/ServerSecurity.java
@@ -323,7 +323,7 @@ public class ServerSecurity {
         String sharedSecret = null;
         sharedSecret = getsharedSecret(clientID);
 
-        return SecurityUtils.encryptAesCbcPkcs5(sharedSecret, bundleID, true);
+        return SecurityUtils.encryptAesCbcPkcs5(sharedSecret, bundleID);
     }
 
     public String createEncryptedBundleId(String clientId, long bundleCounter, boolean downstream) throws

--- a/bundle-core/src/main/java/net/discdd/client/bundlesecurity/ClientSecurity.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundlesecurity/ClientSecurity.java
@@ -8,6 +8,7 @@ import org.whispersystems.libsignal.IdentityKey;
 import org.whispersystems.libsignal.IdentityKeyPair;
 import org.whispersystems.libsignal.InvalidKeyException;
 import org.whispersystems.libsignal.InvalidMessageException;
+import org.whispersystems.libsignal.LegacyMessageException;
 import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.SessionCipher;
 import org.whispersystems.libsignal.SignalProtocolAddress;
@@ -22,6 +23,8 @@ import org.whispersystems.libsignal.state.SessionState;
 import org.whispersystems.libsignal.state.SignalProtocolStore;
 import org.whispersystems.libsignal.util.guava.Optional;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,6 +32,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -197,7 +201,7 @@ public class ClientSecurity {
 
         String secretKey = Base64.getUrlEncoder().encodeToString(agreement);
 
-        return SecurityUtils.encryptAesCbcPkcs5(secretKey, bundleID, true);
+        return SecurityUtils.encryptAesCbcPkcs5(secretKey, bundleID);
     }
 
     /* Add Headers (Identity, Base Key & Bundle ID) to Bundle Path */

--- a/bundleserver/src/test/java/net/discdd/server/End2EndTest.java
+++ b/bundleserver/src/test/java/net/discdd/server/End2EndTest.java
@@ -175,7 +175,7 @@ public class End2EndTest {
 
         String secretKey = Base64.getUrlEncoder().encodeToString(agreement);
 
-        return SecurityUtils.encryptAesCbcPkcs5(secretKey, bundleID, true);
+        return SecurityUtils.encryptAesCbcPkcs5(secretKey, bundleID);
 
     }
 


### PR DESCRIPTION
This reverts commit 7977b200dcd2f7fcd755c0528180c97d78d8a291.

this is not a backwards compatible change.

Server Error:
`bundlepath??:org.whispersystems.libsignal.InvalidKeyException: Bad key type: 111      
          at org.whispersystems.libsignal.ecc.Curve.decodePoint(Curve.java:49)          
  ~[ddd-signal-protocol-java-2.8.1-D2.jar!/:na]                                         
          at org.whispersystems.libsignal.IdentityKey.<init>(IdentityKey.java:28)       
  ~[ddd-signal-protocol-java-2.8.1-D2.jar!/:na]                                         
          at net.discdd.bundlesecurity.ServerSecurity.getCounterFromBundlePath(ServerSe 
  curity.java:384) ~[bundle-core-0.0.2.jar!/:0.0.2]                                     
          at net.discdd.server.bundlesecurity.ServerBundleSecurity.getCounterFromBundle 
  Path(ServerBundleSecurity.java:81) ~[!/:0.0.1-SNAPSHOT]                               
          at net.discdd.server.bundletransmission.ServerBundleTransmission.processRecei 
  vedBundle(ServerBundleTransmission.java:132) ~[!/:0.0.1-SNAPSHOT]                     
          at net.discdd.server.bundletransmission.ServerBundleTransmission.processBundl 
  eFile(ServerBundleTransmission.java:178) ~[!/:0.0.1-SNAPSHOT]                         
          at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMet 
  hodHandleAccessor.java:103) ~[na:na]                                                  
          at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]        
          at org.springframework.aop.support.AopUtils.invokeJoinp`