### PR TITLE
Downgrade first-connection log errors to INFO/WARNING (#793)

### DIFF
--- a/bundle-core/src/main/java/net/discdd/bundlerouting/service/BundleExchangeServiceImpl.java
+++ b/bundle-core/src/main/java/net/discdd/bundlerouting/service/BundleExchangeServiceImpl.java
@@ -31,6 +31,7 @@ import java.util.logging.Logger;
 import static java.lang.String.format;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
 
 public abstract class BundleExchangeServiceImpl extends BundleExchangeServiceGrpc.BundleExchangeServiceImplBase {
     private static final Logger logger = Logger.getLogger(BundleExchangeServiceImpl.class.getName());
@@ -58,7 +59,7 @@ public abstract class BundleExchangeServiceImpl extends BundleExchangeServiceGrp
                                 pathProducer(bundleExchangeName, request.getSenderType(), null);
 
             if (downloadPath == null) {
-                logger.log(SEVERE,
+                logger.log(WARNING,
                            format("Could not produce a path for %s with map %s",
                                   bundleExchangeName.encryptedBundleId,
                                   request.getPublicKeyMap()));

--- a/bundleserver/src/main/java/net/discdd/server/service/BundleServerExchangeServiceImpl.java
+++ b/bundleserver/src/main/java/net/discdd/server/service/BundleServerExchangeServiceImpl.java
@@ -104,6 +104,9 @@ public class BundleServerExchangeServiceImpl extends BundleExchangeServiceImpl {
                                          bundleExchangeName.encryptedBundleId(),
                                          encryptedBundleId));
                 return null;
+            } catch (InvalidKeyException e) {
+                logger.log(INFO, "New client " + senderId + " — keys not yet received, skipping bundle generation");
+                return null;
             } catch (Exception e) {
                 logger.log(SEVERE, "Problem generating bundle for client " + senderId, e);
                 return null;


### PR DESCRIPTION
Suppressed the error as a warning as it should be. The error is not severe as it happens during the first client connection as the download happens before the upload is complete. So it is safe to log it as a warning.