### PR TITLE
Explicit server key mismatch errors when connecting to bundle server

### DIFF
--- a/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/BundleClientService.java
+++ b/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/BundleClientService.java
@@ -354,6 +354,9 @@ public class BundleClientService extends Service {
             if (currentBundle.e() instanceof ClientBundleTransmission.RecencyException) {
                 broadcastBundleClientLogEvent(R.string.not_exchanged_recently_s, currentBundle.e().getMessage());
             }
+            if (currentBundle.e() instanceof ServerKeyMismatchException) {
+                broadcastBundleClientLogEvent(R.string.server_key_mismatch);
+            }
             String text1;
             String text2;
             if (currentBundle.uploadStatus() == Statuses.FAILED) {

--- a/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/ServerViewModel.kt
+++ b/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/ServerViewModel.kt
@@ -16,6 +16,7 @@ import net.discdd.bundleclient.service.BundleClientService
 import net.discdd.bundlesecurity.DDDPEMEncoder
 import net.discdd.bundlesecurity.SecurityUtils
 import net.discdd.client.bundlesecurity.ClientSecurity
+import net.discdd.client.bundletransmission.ServerKeyMismatchException
 import net.discdd.utils.QRCodeParser
 import java.nio.file.Files
 
@@ -88,6 +89,9 @@ class ServerViewModel(
                                     bec.downloadStatus()
                                 )
                             )
+                            if (bec.e() is ServerKeyMismatchException) {
+                                appendMessage(context.getString(R.string.server_key_mismatch))
+                            }
                             _isTransmitting.value = false
                         }
                 } ?: run {

--- a/AndroidApps/BundleClient/app/src/main/res/values/strings.xml
+++ b/AndroidApps/BundleClient/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="not_exchanged_recently_s">Transport has not exchanged with server recently: %s</string>
     <string name="timeout_connecting_to_s">Timeout connecting to %s perhaps not accepting connection?</string>
     <string name="could_not_start_exchange">"Could not start exchange: "</string>
+    <string name="server_key_mismatch">Server key mismatch. The server certificate does not match.</string>
     <string name="no_changes_detected">No changes detected.</string>
     <string name="changes_reverted">Changes reverted.</string>
     <string name="unknown_transportId">"Unknown"</string>

--- a/bundle-core/src/main/java/net/discdd/client/bundletransmission/ClientBundleTransmission.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundletransmission/ClientBundleTransmission.java
@@ -269,12 +269,12 @@ public class ClientBundleTransmission {
         }
         var receivedServerPublicKey = Curve.decodePoint(recencyBlobResponse.getServerPublicKey().toByteArray(), 0);
         if (!bundleSecurity.getClientSecurity().getServerPublicKey().equals(receivedServerPublicKey)) {
-            throw new RecencyException("Recency blob signed by unknown server");
+            throw new ServerKeyMismatchException("Recency blob signed by unknown server");
         }
         if (!SecurityUtils.verifySignatureRaw(recencyBlob.toByteArray(),
                                               receivedServerPublicKey,
                                               recencyBlobResponse.getRecencyBlobSignature().toByteArray())) {
-            throw new RecencyException("Recency blob signature verification failed");
+            throw new ServerKeyMismatchException("Recency blob signature verification failed");
         }
         return recencyTracker.isNewerRecencyBlob(device, recencyBlobResponse);
     }

--- a/bundle-core/src/main/java/net/discdd/client/bundletransmission/ServerKeyMismatchException.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundletransmission/ServerKeyMismatchException.java
@@ -1,0 +1,13 @@
+package net.discdd.client.bundletransmission;
+
+import java.io.IOException;
+
+public class ServerKeyMismatchException extends IOException {
+    public ServerKeyMismatchException(String message) {
+        super(message);
+    }
+
+    public ServerKeyMismatchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
Resolves #808 . Attached screenshots of how the error appears now.
When connecting from Client to Transport:
<img width="360" alt="Screenshot_20260514_000933_DDD Client" src="https://github.com/user-attachments/assets/7c28f86d-7049-4d09-8976-aa6818167104" />

When connecting from Client to Server:
<img width="360" alt="Screenshot_20260513_235551_DDD Client" src="https://github.com/user-attachments/assets/9daa4cff-12a3-4ecc-9953-26f7385bb021" />
