### PR TITLE
Display server key mismatch error when unable to connect bundle server

### DIFF
--- a/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/BundleClientService.java
+++ b/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/service/BundleClientService.java
@@ -38,6 +38,7 @@ import net.discdd.bundleclient.utils.RecentTransport;
 import net.discdd.bundleclient.utils.RecentTransportRepository;
 import net.discdd.client.bundletransmission.ClientBundleTransmission;
 import net.discdd.client.bundletransmission.ClientBundleTransmission.BundleExchangeCounts;
+import net.discdd.client.bundletransmission.ClientBundleTransmission.ServerKeyMismatchException;
 import net.discdd.client.bundletransmission.ClientBundleTransmission.Statuses;
 import net.discdd.client.bundletransmission.TransportDevice;
 import net.discdd.datastore.providers.MessageProvider;
@@ -351,7 +352,9 @@ public class BundleClientService extends Service {
                                                  device.getDescription(),
                                                  statusesToString(currentBundle.uploadStatus()),
                                                  statusesToString(currentBundle.downloadStatus()));
-            if (currentBundle.e() instanceof ClientBundleTransmission.RecencyException) {
+            if (currentBundle.e() instanceof ServerKeyMismatchException) {
+                broadcastBundleClientLogEvent(R.string.server_key_mismatch);
+            } else if (currentBundle.e() instanceof ClientBundleTransmission.RecencyException) {
                 broadcastBundleClientLogEvent(R.string.not_exchanged_recently_s, currentBundle.e().getMessage());
             }
             String text1;

--- a/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/ServerViewModel.kt
+++ b/AndroidApps/BundleClient/app/src/main/java/net/discdd/bundleclient/viewmodels/ServerViewModel.kt
@@ -16,6 +16,7 @@ import net.discdd.bundleclient.service.BundleClientService
 import net.discdd.bundlesecurity.DDDPEMEncoder
 import net.discdd.bundlesecurity.SecurityUtils
 import net.discdd.client.bundlesecurity.ClientSecurity
+import net.discdd.client.bundletransmission.ClientBundleTransmission.ServerKeyMismatchException
 import net.discdd.utils.QRCodeParser
 import java.nio.file.Files
 
@@ -88,6 +89,9 @@ class ServerViewModel(
                                     bec.downloadStatus()
                                 )
                             )
+                            if (bec.e() is ServerKeyMismatchException) {
+                                appendMessage(context.getString(R.string.server_key_mismatch))
+                            }
                             _isTransmitting.value = false
                         }
                 } ?: run {

--- a/AndroidApps/BundleClient/app/src/main/res/values/strings.xml
+++ b/AndroidApps/BundleClient/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="not_exchanged_recently_s">Transport has not exchanged with server recently: %s</string>
     <string name="timeout_connecting_to_s">Timeout connecting to %s perhaps not accepting connection?</string>
     <string name="could_not_start_exchange">"Could not start exchange: "</string>
+    <string name="server_key_mismatch">Server key mismatch. The server certificate does not match.</string>
     <string name="no_changes_detected">No changes detected.</string>
     <string name="changes_reverted">Changes reverted.</string>
     <string name="unknown_transportId">"Unknown"</string>

--- a/bundle-core/src/main/java/net/discdd/client/bundletransmission/ClientBundleTransmission.java
+++ b/bundle-core/src/main/java/net/discdd/client/bundletransmission/ClientBundleTransmission.java
@@ -94,6 +94,12 @@ public class ClientBundleTransmission {
         }
     }
 
+    public static class ServerKeyMismatchException extends RecencyException {
+        public ServerKeyMismatchException(String message) {
+            super(message);
+        }
+    }
+
     private static final Logger logger = Logger.getLogger(ClientBundleTransmission.class.getName());
     private final ExecutorService executorService = Executors.newCachedThreadPool();
     private final ClientBundleSecurity bundleSecurity;
@@ -269,12 +275,12 @@ public class ClientBundleTransmission {
         }
         var receivedServerPublicKey = Curve.decodePoint(recencyBlobResponse.getServerPublicKey().toByteArray(), 0);
         if (!bundleSecurity.getClientSecurity().getServerPublicKey().equals(receivedServerPublicKey)) {
-            throw new RecencyException("Recency blob signed by unknown server");
+            throw new ServerKeyMismatchException("Recency blob signed by unknown server");
         }
         if (!SecurityUtils.verifySignatureRaw(recencyBlob.toByteArray(),
                                               receivedServerPublicKey,
                                               recencyBlobResponse.getRecencyBlobSignature().toByteArray())) {
-            throw new RecencyException("Recency blob signature verification failed");
+            throw new ServerKeyMismatchException("Recency blob signature verification failed");
         }
         return recencyTracker.isNewerRecencyBlob(device, recencyBlobResponse);
     }


### PR DESCRIPTION
Resolves https://github.com/SJSU-CS-systems-group/DDD/issues/808 .
Manual verification done:
- Scanned server QR in BundleClient and confirmed normal server exchange works.
- Regenerated Bundle Server keys and restarted server without rescanning QR in BundleClient.

- BundleClient -> BundleServer mismatch shown in Server tab:
<img width="340" alt="BundleClient server key mismatch in Server tab" src="https://github.com/user-attachments/assets/481306db-d6f4-4b19-9a9a-e3aa3529f898" />

- BundleClient -> BundleTransport mismatch shown in local exchange logs:
<img width="340" alt="BundleClient server key mismatch during transport exchange" src="https://github.com/user-attachments/assets/b3f9063b-6494-45b1-8849-975105dc9756" />
